### PR TITLE
is_overseas fix

### DIFF
--- a/talentmap_api/integrations/synchronization_helpers.py
+++ b/talentmap_api/integrations/synchronization_helpers.py
@@ -394,7 +394,7 @@ def mode_positions(last_updated_date=None):
         "org_code": "_org_code",
         "bureau_code": "_bureau_code",
         "skill_code": "_skill_code",
-        "is_overseas": parse_boolean("is_overseas", ['O']),
+        "is_overseas": parse_boolean("is_overseas"),
         "grade": "_grade_code",
         "tod_code": set_foreign_key_by_filters("tour_of_duty", "code", "__icontains"),
         "language_code_1": "_language_1_code",

--- a/talentmap_api/integrations/tests/test_soap_synchronization.py
+++ b/talentmap_api/integrations/tests/test_soap_synchronization.py
@@ -36,6 +36,9 @@ def test_soap_integrations():
     assert BidCycle.objects.get(_id="151").positions.count() == 6
     assert BiddingStatus.objects.count() == 10
 
+    # Assert is_overseas
+    assert Position.objects.get(_seq_num="1640").is_overseas == True
+
     call_command('synchronize_data', '--list')
 
     first_skill = Skill.objects.first()


### PR DESCRIPTION
Defect found by Robin.  The Post: Domestic/Overseas filters were not behaving as expected.  Based on testing it looks like all positions were marked as `is_overseas = False` by default.