### PR TITLE
feature: add can_delete property to bid

### DIFF
--- a/talentmap_api/bidding/models.py
+++ b/talentmap_api/bidding/models.py
@@ -175,6 +175,11 @@ class Bid(StaticRepresentationModel):
     def is_paneling_today(self):
         return timezone.now().date() == self.scheduled_panel_date.date()
 
+    @property
+    def can_delete(self):
+        ''' Whether or not a bid can be deleted '''
+        return self.status in [Bid.Status.draft, Bid.Status.submitted, Bid.Status.handshake_offered]
+
     @staticmethod
     def get_approval_statuses():
         '''

--- a/talentmap_api/bidding/serializers/serializers.py
+++ b/talentmap_api/bidding/serializers/serializers.py
@@ -112,6 +112,7 @@ class BidSerializer(PrefetchedSerializer):
     position = StaticRepresentationField(read_only=True)
     waivers = StaticRepresentationField(read_only=True, many=True)
     is_paneling_today = serializers.BooleanField(read_only=True)
+    can_delete = serializers.BooleanField(read_only=True)
 
     class Meta:
         model = Bid

--- a/talentmap_api/bidding/tests/test_bid.py
+++ b/talentmap_api/bidding/tests/test_bid.py
@@ -175,6 +175,7 @@ def test_bid_ao_actions(authorized_client, authorized_user):
     in_bureau_bid.refresh_from_db()
     assert in_bureau_bid.status == Bid.Status.handshake_offered
     assert in_bureau_bid.handshake_offered_date.date() == timezone.now().date()
+    assert in_bureau_bid.can_delete
 
     # Accept the handshakes
     in_bureau_bid.status = Bid.Status.handshake_accepted
@@ -196,6 +197,7 @@ def test_bid_ao_actions(authorized_client, authorized_user):
     assert in_bureau_bid.in_panel_date.date() == timezone.now().date()
     assert in_bureau_bid.scheduled_panel_date == panel_date.astimezone(datetime.timezone.utc)
     assert not in_bureau_bid.is_paneling_today
+    assert not in_bureau_bid.can_delete
     assert in_bureau_bid.is_priority
     assert in_bureau_bid.panel_reschedule_count == 0
 
@@ -211,6 +213,7 @@ def test_bid_ao_actions(authorized_client, authorized_user):
     assert in_bureau_bid.in_panel_date.date() == timezone.now().date()
     assert in_bureau_bid.scheduled_panel_date == today.astimezone(datetime.timezone.utc)
     assert in_bureau_bid.is_paneling_today
+    assert not in_bureau_bid.can_delete
     assert in_bureau_bid.panel_reschedule_count == 1
 
     # Patch an out-of-bureau bid
@@ -231,6 +234,7 @@ def test_bid_ao_actions(authorized_client, authorized_user):
     assert in_bureau_bid.status == Bid.Status.approved
     assert in_bureau_bid.approved_date.date() == timezone.now().date()
     assert in_bureau_bid.is_priority
+    assert not in_bureau_bid.can_delete
 
     response = authorized_client.get(f'/api/v1/bid/{out_of_bureau_bid.id}/approve/')
     assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -243,6 +247,7 @@ def test_bid_ao_actions(authorized_client, authorized_user):
     assert in_bureau_bid.status == Bid.Status.declined
     assert in_bureau_bid.declined_date.date() == timezone.now().date()
     assert not in_bureau_bid.is_priority
+    assert not in_bureau_bid.can_delete
 
     response = authorized_client.get(f'/api/v1/bid/{out_of_bureau_bid.id}/decline/')
     assert response.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
Adds a can_delete property to bids so front end does not need to calculate this each time. 