### PR TITLE
Security fix - PyYAML

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -64,7 +64,6 @@ pytest-cov==2.5.1
 pytest-django==3.1.2
 python-dateutil==2.7.2
 pytz==2018.3
-PyYAML==3.12
 pyzmq==17.0.0
 repoze.who==2.3
 requests==2.18.4


### PR DESCRIPTION
We received a vulnerability disclosure from GitHub indicating we need to upgrade.  From what I see we don't seem to require this library anymore (requirements changed).