### PR TITLE
feature: bidder role restricting access to bidder actions

### DIFF
--- a/talentmap_api/bidding/tests/test_bid.py
+++ b/talentmap_api/bidding/tests/test_bid.py
@@ -17,8 +17,14 @@ def test_bidlist_fixture():
         bidcycle.positions.add(mommy.make('position.Position'))
 
 
+@pytest.fixture
+def test_bidder_fixture(authorized_user):
+    group = mommy.make('auth.Group', name='bidder')
+    group.user_set.add(authorized_user)
+
+
 @pytest.mark.django_db(transaction=True)
-@pytest.mark.usefixtures("test_bidlist_fixture")
+@pytest.mark.usefixtures("test_bidlist_fixture", "test_bidder_fixture")
 def test_bid_bidder_actions(authorized_client, authorized_user):
     in_cycle_position = BidCycle.objects.first().positions.first()
 
@@ -90,7 +96,7 @@ def test_bid_bidder_actions(authorized_client, authorized_user):
 
 
 @pytest.mark.django_db(transaction=True)
-@pytest.mark.usefixtures("test_bidlist_fixture")
+@pytest.mark.usefixtures("test_bidlist_fixture", "test_bidder_fixture")
 def test_bid_bidder_priority_restrictions(authorized_client, authorized_user):
     in_cycle_position = BidCycle.objects.first().positions.first()
 
@@ -254,7 +260,7 @@ def test_bid_ao_actions(authorized_client, authorized_user):
 
 
 @pytest.mark.django_db(transaction=True)
-@pytest.mark.usefixtures("test_bidlist_fixture")
+@pytest.mark.usefixtures("test_bidlist_fixture", "test_bidder_fixture")
 def test_bidlist_max_submissions(authorized_client, authorized_user):
     bidcycle = BidCycle.objects.get(id=1)
     position = mommy.make('position.Position')

--- a/talentmap_api/bidding/tests/test_bidlist.py
+++ b/talentmap_api/bidding/tests/test_bidlist.py
@@ -19,6 +19,12 @@ def test_bidlist_fixture():
         bidcycle.positions.add(mommy.make('position.Position', post=post))
 
 
+@pytest.fixture
+def test_bidder_fixture(authorized_user):
+    group = mommy.make('auth.Group', name='bidder')
+    group.user_set.add(authorized_user)
+
+
 @pytest.mark.django_db(transaction=True)
 def test_can_accept_new_bids_function(authorized_client, authorized_user, test_bidlist_fixture):
     active_cycle = BidCycle.objects.first()
@@ -34,7 +40,7 @@ def test_can_accept_new_bids_function(authorized_client, authorized_user, test_b
 
 
 @pytest.mark.django_db(transaction=True)
-@pytest.mark.usefixtures("test_bidlist_fixture")
+@pytest.mark.usefixtures("test_bidlist_fixture", "test_bidder_fixture")
 def test_bidlist_position_actions(authorized_client, authorized_user):
     in_cycle_position = BidCycle.objects.first().positions.first()
     out_of_cycle_position = mommy.make('position.Position')
@@ -113,7 +119,7 @@ def test_bidlist_position_actions(authorized_client, authorized_user):
 
 
 @pytest.mark.django_db(transaction=True)
-@pytest.mark.usefixtures("test_bidlist_fixture")
+@pytest.mark.usefixtures("test_bidlist_fixture", "test_bidder_fixture")
 def test_bidlist_date_based_deletion(authorized_client, authorized_user):
     bidcycle = BidCycle.objects.get(id=1)
 

--- a/talentmap_api/bidding/views/bid.py
+++ b/talentmap_api/bidding/views/bid.py
@@ -106,7 +106,7 @@ class BidListBidderActionView(GenericViewSet):
     Supports all bidder actions for a bid
     '''
 
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, isDjangoGroupMember('bidder'),)
 
     def submit(self, request, pk, format=None):
         '''

--- a/talentmap_api/bidding/views/bidlist.py
+++ b/talentmap_api/bidding/views/bidlist.py
@@ -17,6 +17,7 @@ from talentmap_api.bidding.models import Bid, BidCycle
 from talentmap_api.bidding.filters import BidFilter
 from talentmap_api.user_profile.models import UserProfile
 from talentmap_api.messaging.models import Notification
+from talentmap_api.common.permissions import isDjangoGroupMember
 
 import logging
 logger = logging.getLogger(__name__)
@@ -30,7 +31,7 @@ class BidListView(mixins.ListModelMixin,
     '''
     serializer_class = BidSerializer
     filter_class = BidFilter
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, isDjangoGroupMember('bidder'),)
 
     def destroy(self, request, *args, **kwargs):
         '''

--- a/talentmap_api/common/management/commands/create_base_permissions.py
+++ b/talentmap_api/common/management/commands/create_base_permissions.py
@@ -13,6 +13,7 @@ class Command(BaseCommand):
         super(Command, self).__init__(*args, **kwargs)
 
         self.groups = [
+            "bidder",
             "bureau_ao",
             "glossary_editors",
             "feedback_editors",

--- a/talentmap_api/user_profile/management/commands/create_seeded_users.py
+++ b/talentmap_api/user_profile/management/commands/create_seeded_users.py
@@ -50,6 +50,10 @@ class Command(BaseCommand):
 
                 assignment = Assignment.objects.create(user=profile, position=position, tour_of_duty=TourOfDuty.objects.all().first(), start_date=timezone.now(), status="active", bid_approval_date="1975-01-01T00:00:00Z")
 
+                # Add user to the bidder group
+                group = get_group_by_name("bidder")
+                group.user_set.add(user)
+
                 # Add the user to the editing group for their position
                 group = get_group_by_name(f"post_editors:{position.post.id}")
                 group.user_set.add(user)


### PR DESCRIPTION
TM-403 - adds the bidder role and restricts access to some of the end points around bidding to this role.

The bidder role needs to be assigned to any user that would want to perform these actions