### PR TITLE
Client assignments endpoint

### DIFF
--- a/talentmap_api/position/serializers.py
+++ b/talentmap_api/position/serializers.py
@@ -50,11 +50,13 @@ class AssignmentSerializer(CurrentAssignmentSerializer):
                 "field": "position",
                 "kwargs": {
                     "override_fields": [
+                        "id",
                         "position_number",
                         "bureau",
                         "skill",
                         "title",
                         "post__location",
+                        "languages",
                     ],
                     "read_only": True
                 }

--- a/talentmap_api/user_profile/urls/client.py
+++ b/talentmap_api/user_profile/urls/client.py
@@ -9,6 +9,7 @@ urlpatterns = [
     url(r'^(?P<pk>[0-9]+)/$', views.CdoClientView.as_view(get_retrieve), name='user_profile.UserProfile-client-detail'),
     url(r'^(?P<pk>[0-9]+)/survey/$', views.CdoClientSurveyView.as_view(get_list), name='bidding.StatusSurvey-client-list'),
     url(r'^(?P<pk>[0-9]+)/bids/$', views.CdoClientBidView.as_view(get_list), name='bidding.Bid-client-list'),
+    url(r'^(?P<pk>[0-9]+)/assignments/$', views.CdoClientAssignmentView.as_view(get_list), name='bidding.Bid-client-list'),
     url(r'^(?P<pk>[0-9]+)/bids/(?P<bid_id>[0-9]+)/prepanel/$', views.CdoClientBidView.as_view(get_retrieve), name='bidding.Bid-client-retrieve'),
     url(r'^(?P<pk>[0-9]+)/waivers/$', views.CdoClientWaiverView.as_view(get_list), name='bidding.Waiver-client-list'),
 ]

--- a/talentmap_api/user_profile/views/client.py
+++ b/talentmap_api/user_profile/views/client.py
@@ -15,6 +15,8 @@ from talentmap_api.bidding.serializers.serializers import SurveySerializer, BidS
 from talentmap_api.bidding.serializers.prepanel import PrePanelSerializer
 from talentmap_api.bidding.filters import StatusSurveyFilter, BidFilter, WaiverFilter
 from talentmap_api.bidding.models import StatusSurvey, Bid, Waiver
+from talentmap_api.position.serializers import AssignmentSerializer
+from talentmap_api.position.filters import AssignmentFilter
 
 from talentmap_api.user_profile.models import UserProfile
 from talentmap_api.user_profile.filters import ClientFilter
@@ -90,6 +92,23 @@ class CdoClientSurveyView(FieldLimitableSerializerMixin,
         self.serializer_class.prefetch_model(StatusSurvey, queryset)
         return queryset
 
+class CdoClientAssignmentView(FieldLimitableSerializerMixin,
+                          mixins.ListModelMixin,
+                          GenericViewSet):
+    """
+    list:
+    Lists all of the specified client's assignments
+    """
+
+    serializer_class = AssignmentSerializer
+    permission_classes = (IsAuthenticated,)
+    filter_class = AssignmentFilter
+
+    def get_queryset(self):
+        client = get_object_or_404(UserProfile.objects.filter(cdo=self.request.user.profile), id=self.request.parser_context.get("kwargs").get("pk"))
+        queryset = client.assignments.all()
+        self.serializer_class.prefetch_model(StatusSurvey, queryset)
+        return queryset
 
 class CdoClientBidView(FieldLimitableSerializerMixin,
                        ActionDependentSerializerMixin,


### PR DESCRIPTION
Updates to API that were needed for the public profile page:

- Add new endpoint for clients by assignment (/client/:id/assignments)
- Include `id` and `languages` in the assignment's `position` object