### PR TITLE
WIP - initial stab at getting a queue system in place

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 services:
   app:
     build:
@@ -7,8 +7,10 @@ services:
       - 8000:8000
     links:
       - db
+      - queue
     depends_on:
       - db
+      - queue
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
       - .:/app
@@ -23,5 +25,25 @@ services:
     environment:
       - POSTGRES_DB=talentmap
       - POSTGRES_USER=talentmap-user
+  queue:
+    image: rabbitmq:3-management
+    hostname: "rabbittm"
+    environment:
+      RABBITMQ_ERLANG_COOKIE: "XXXXTALENTMAPXXXX"
+      RABBITMQ_DEFAULT_USER: "rabbitmq"
+      RABBITMQ_DEFAULT_PASS: "rabbitmq"
+      RABBITMQ_DEFAULT_VHOST: "/"
+    ports:
+      - "15672:15672"
+      - "5672:5672"
+    labels:
+      NAME: "rabbitmqtm"
+  flower:
+    depends_on:
+      - queue
+    image: mher/flower
+    command: flower --broker=amqp://rabbitmq:rabbitmq@queue:5672// --port=8888  
+    ports:  
+      - 8888:8888  
 volumes:
   pgdata:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ asn1crypto==0.24.0
 attrs==17.4.0
 bandit==1.4.0
 cached-property==1.4.2
+Celery==4.2.0
 certifi==2018.1.18
 cffi==1.11.5
 chardet==3.0.4

--- a/talentmap_api/__init__.py
+++ b/talentmap_api/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import, unicode_literals
+
+# This will make sure the app is always imported when
+# Django starts so that shared_task will use this app.
+from .celery import app as celery_app
+
+__all__ = ('celery_app',)

--- a/talentmap_api/bidding/models.py
+++ b/talentmap_api/bidding/models.py
@@ -15,6 +15,7 @@ from talentmap_api.common.models import StaticRepresentationModel
 from talentmap_api.messaging.models import Notification
 from talentmap_api.user_profile.models import UserProfile
 
+from talentmap_api.bidding.tasks import push_bid
 
 class BidCycle(StaticRepresentationModel):
     '''
@@ -295,6 +296,9 @@ def bidcycle_positions_update(sender, instance, action, reverse, model, pk_set, 
                 pos.latest_bidcycle = None
             pos.save()
 
+@receiver(post_save, sender=Bid, dispatch_uid="test_bid_queue")
+def test_bid_queue(sender, instance, **kwargs):
+    push_bid.delay(instance.id)
 
 @receiver(pre_save, sender=Bid, dispatch_uid="bid_status_changed")
 def bid_status_changed(sender, instance, **kwargs):

--- a/talentmap_api/bidding/tasks.py
+++ b/talentmap_api/bidding/tasks.py
@@ -1,0 +1,8 @@
+# Create your tasks here
+from __future__ import absolute_import, unicode_literals
+from celery import shared_task
+
+@shared_task
+def push_bid(id):
+    return id
+

--- a/talentmap_api/celery.py
+++ b/talentmap_api/celery.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import, unicode_literals
+import os
+from celery import Celery
+
+# set the default Django settings module for the 'celery' program.
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'talentmap_api.settings')
+
+app = Celery('talentmap_api')
+
+# Using a string here means the worker doesn't have to serialize
+# the configuration object to child processes.
+# - namespace='CELERY' means all celery-related configuration keys
+#   should have a `CELERY_` prefix.
+app.config_from_object('django.conf:settings', namespace='CELERY')
+
+# Load task modules from all registered Django app configs.
+app.autodiscover_tasks()
+
+
+@app.task(bind=True)
+def debug_task(self):
+    print('Request: {0!r}'.format(self.request))

--- a/talentmap_api/settings.py
+++ b/talentmap_api/settings.py
@@ -478,3 +478,7 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'talentmap_api/static/')
+
+# Celery
+CELERY_BROKER_URL = 'amqp://rabbitmq:rabbitmq@queue:5672'
+CELERY_BACKEND = 'rpc://'


### PR DESCRIPTION
Addresses TM-537

This is the first stab at what could be a more robust queuing solution for our sync tasks that currently occur as well as setting the ground work for any additional integrations that would be needed in the future. There are a few things that I need to clean up before moving forward on this as well as documenting how to run this in a non-docker environment.

For testing:
 - `docker-compose build`
 - `docker-compose up`
 - `docker-compose run app celery worker --app=talentmap_api -l info`
 - From the API, perform some action that saves a bid (`PUT /api/v1/bidlist/position/{id}/` for example)
 - Go to `localhost:8888` and click on Tasks in the menu. You should see the task that ran.
 - You can also insect the RabbitMQ queue by going to `localhost:15672`

