### PR TITLE
feature: allow for language and no language requirement filters to be used together. TM-401

### DIFF
--- a/talentmap_api/position/filters.py
+++ b/talentmap_api/position/filters.py
@@ -84,6 +84,7 @@ class PositionBidStatisticsFilter(filters.FilterSet):
 
 class PositionFilter(filters.FilterSet):
     languages = filters.RelatedFilter(QualificationFilter, name='languages', queryset=Qualification.objects.all())
+    language_codes = filters.Filter(name='language_codes', method="filter_language_codes")
     description = filters.RelatedFilter(CapsuleDescriptionFilter, name='description', queryset=CapsuleDescription.objects.all())
     grade = filters.RelatedFilter(GradeFilter, name='grade', queryset=Grade.objects.all())
     skill = filters.RelatedFilter(SkillFilter, name='skill', queryset=Skill.objects.all())
@@ -120,6 +121,17 @@ class PositionFilter(filters.FilterSet):
 
     is_available_in_bidcycle = filters.Filter(name="bid_cycles", method="filter_available_in_bidcycle")
     vacancy_in_years = filters.NumberFilter(name="current_assignment__estimated_end_date", method="filter_vacancy_in_years")
+
+    def filter_language_codes(self, queryset, name, value):
+        '''
+        Returns a queryset of all languages that match the codes provided.
+        If NONE is provided, all positions with no language requirement will also be returned
+        '''
+        langs = value.split(',')
+        query = Q(languages__language__code__in=langs)
+        if 'NONE' in value:
+            query = query | Q(languages__isnull=True)
+        return queryset.filter(query)
 
     def filter_available_in_bidcycle(self, queryset, name, value):
         '''

--- a/talentmap_api/position/tests/test_position_endpoints.py
+++ b/talentmap_api/position/tests/test_position_endpoints.py
@@ -62,6 +62,10 @@ def test_position_filtering(client):
     assert response.status_code == status.HTTP_200_OK
     assert len(response.data["results"]) == 2
 
+    response = client.get('/api/v1/position/?language_codes=DE')
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.data["results"]) == 2
+
     response = client.get('/api/v1/position/?languages__spoken_proficiency__at_least=3')
     assert response.status_code == status.HTTP_200_OK
     assert len(response.data["results"]) == 2


### PR DESCRIPTION
Adds a new filter language_code that accepts language codes as well as a special value `NONE` that uses the language__isnull filter.

`language_codes=QB,DE,NONE` = all positions with language requirements with code QB and DE as well as positions that have no language requirement. 