### PR TITLE
fix: use distinct to only return one of each position. TM-401

### DIFF
--- a/talentmap_api/position/filters.py
+++ b/talentmap_api/position/filters.py
@@ -131,7 +131,7 @@ class PositionFilter(filters.FilterSet):
         query = Q(languages__language__code__in=langs)
         if 'NONE' in value:
             query = query | Q(languages__isnull=True)
-        return queryset.filter(query)
+        return queryset.filter(query).distinct()
 
     def filter_available_in_bidcycle(self, queryset, name, value):
         '''


### PR DESCRIPTION
solves issue with a position with multiple languages showing up twice