### PR TITLE
Add assignment history to client response

### DIFF
--- a/talentmap_api/position/serializers.py
+++ b/talentmap_api/position/serializers.py
@@ -294,6 +294,7 @@ class PositionSerializer(PrefetchedSerializer):
             }
         }
 
+
 class AssignmentPositionSerializer(PrefetchedSerializer):
     grade = StaticRepresentationField(read_only=True)
     skill = StaticRepresentationField(read_only=True)
@@ -371,6 +372,7 @@ class AssignmentPositionSerializer(PrefetchedSerializer):
                 }
             }
         }
+
 
 class GradeSerializer(PrefetchedSerializer):
 

--- a/talentmap_api/position/serializers.py
+++ b/talentmap_api/position/serializers.py
@@ -42,7 +42,21 @@ class CurrentAssignmentSerializer(PrefetchedSerializer):
 
     class Meta:
         model = Assignment
-        exclude = ("position",)
+        fields = "__all__"
+        nested = {
+            "position": {
+                "class": "talentmap_api.position.serializers.AssignmentPositionSerializer",
+                "field": "position",
+                "kwargs": {
+                    "override_fields": [
+                        "id",
+                        "post__location",
+                        "current_assignment"
+                    ],
+                    "read_only": True
+                }
+            }
+        }
 
 
 class AssignmentSerializer(CurrentAssignmentSerializer):
@@ -280,6 +294,83 @@ class PositionSerializer(PrefetchedSerializer):
             }
         }
 
+class AssignmentPositionSerializer(PrefetchedSerializer):
+    grade = StaticRepresentationField(read_only=True)
+    skill = StaticRepresentationField(read_only=True)
+    bureau = serializers.SerializerMethodField()
+    organization = serializers.SerializerMethodField()
+    tour_of_duty = StaticRepresentationField(read_only=True)
+    classifications = StaticRepresentationField(read_only=True, many=True)
+    representation = serializers.SerializerMethodField()
+    availability = serializers.SerializerMethodField()
+
+    # This method returns the string representation of the bureau, or the code
+    # if it doesn't currently exist in the database
+    def get_bureau(self, obj):
+        if obj.bureau:
+            return obj.bureau._string_representation
+        else:
+            return obj._bureau_code
+
+    # This method returns the string representation of the parent org, or the code
+    # if it doesn't currently exist in the database
+    def get_organization(self, obj):
+        if obj.organization:
+            return obj.organization._string_representation
+        else:
+            return obj._org_code
+
+    def get_availability(self, obj):
+        return obj.availability
+
+    class Meta:
+        model = Position
+        fields = "__all__"
+        nested = {
+            "bid_cycle_statuses": {
+                "class": BiddingStatusSerializer,
+                "kwargs": {
+                    "many": True,
+                    "read_only": True
+                }
+            },
+            "bid_statistics": {
+                "class": PositionBidStatisticsSerializer,
+                "kwargs": {
+                    "many": True,
+                    "read_only": True
+                }
+            },
+            "languages": {
+                "class": LanguageQualificationSerializer,
+                "kwargs": {
+                    "many": True,
+                    "read_only": True
+                }
+            },
+            "post": {
+                "class": PostSerializer,
+                "field": "post",
+                "kwargs": {
+                    "many": False,
+                    "read_only": True
+                }
+            },
+            "description": {
+                "class": CapsuleDescriptionSerializer,
+                "field": "description",
+                "kwargs": {
+                    "read_only": True
+                }
+            },
+            "latest_bidcycle": {
+                "class": "talentmap_api.bidding.serializers.serializers.BidCycleSerializer",
+                "field": "latest_bidcycle",
+                "kwargs": {
+                    "read_only": True
+                }
+            }
+        }
 
 class GradeSerializer(PrefetchedSerializer):
 

--- a/talentmap_api/user_profile/serializers.py
+++ b/talentmap_api/user_profile/serializers.py
@@ -5,7 +5,7 @@ from talentmap_api.common.common_helpers import resolve_path_to_view, validate_f
 from talentmap_api.bidding.serializers.serializers import UserBidStatisticsSerializer
 from talentmap_api.common.serializers import PrefetchedSerializer, StaticRepresentationField
 from talentmap_api.language.serializers import LanguageQualificationSerializer
-from talentmap_api.position.serializers import PositionSerializer, SkillSerializer
+from talentmap_api.position.serializers import PositionSerializer, SkillSerializer, CurrentAssignmentSerializer
 from talentmap_api.messaging.serializers import SharableSerializer
 
 from django.contrib.auth.models import User
@@ -73,9 +73,15 @@ class ClientSerializer(PrefetchedSerializer):
         else:
             return None
 
+    def get_assignment(self, obj):
+        if obj.assignments.count() > 0:
+            return str(obj.assignments.latest('start_date'))
+        else:
+            return None
+
     class Meta:
         model = UserProfile
-        fields = ["id", "current_assignment", "skills", "grade", "is_cdo", "primary_nationality", "secondary_nationality", "bid_statistics", "user", "language_qualifications", "initials", "display_name"]
+        fields = ["id", "current_assignment", "assignments", "skills", "grade", "is_cdo", "primary_nationality", "secondary_nationality", "bid_statistics", "user", "language_qualifications", "initials", "display_name"]
         nested = {
             "user": {
                 "class": UserSerializer,
@@ -103,6 +109,13 @@ class ClientSerializer(PrefetchedSerializer):
             },
             "skills": {
                 "class": SkillSerializer,
+                "kwargs": {
+                    "many": True,
+                    "read_only": True
+                }
+            },
+            "assignments": {
+                "class": CurrentAssignmentSerializer,
                 "kwargs": {
                     "many": True,
                     "read_only": True


### PR DESCRIPTION
Adds client's assignment history to response data to support new feature in the bidder portfolio.