### PR TITLE
feature: basic projected vacancies get end point

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -32,6 +32,7 @@ source setup_environment.sh
 export DATABASE_URL='<DATABASE_URL>'
 export DJANGO_LOG_DIRECTORY='/home/ec2-user/log/'
 export DEPLOYMENT_LOCATION='/home/ec2-user/State-TalentMAP-API-dev/'
+export FSBID_API_URL='http://dev.talentmap.fsbid.metaphasedev.com'
 
 # install dependencies
 pip install -r requirements.txt

--- a/talentmap_api/fsbid/services.py
+++ b/talentmap_api/fsbid/services.py
@@ -120,8 +120,8 @@ def convert_pv_query(query):
     "tourOfDutyCode": query.get("post__tour_of_duty__code__in"),
     "limit": query.get("limit", None),
     "page": query.get("page", None),
-    # These filters are supported by FSBid but not TalentMap
-    "organizationCode": None,
+    "organizationCode": query.get("post__in"),
+    # Filters are supported by FSBid but not TalentMap
     "positionNumber": None
   }
   return urlencode({i:j for i,j in values.items() if j is not None})

--- a/talentmap_api/fsbid/services.py
+++ b/talentmap_api/fsbid/services.py
@@ -1,6 +1,8 @@
 import requests
 import logging
 
+from urllib.parse import urlencode
+
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
@@ -70,9 +72,24 @@ def fsbid_bid_to_talentmap_bid(data):
       }
     }
 
-def get_projected_vacancies():
-  projected_vacancies = requests.get(f"{API_ROOT}/projectedVacancies").json()
+def get_projected_vacancies(query):
+  projected_vacancies = requests.get(f"{API_ROOT}/projectedVacancies?{convert_pv_query(query)}").json()
   return  map(fsbid_pv_to_talentmap_pv, projected_vacancies)
+
+def convert_pv_query(query):
+  values = {
+    "bsn_id": query.get("is_available_in_bidseason"),
+    "bureauCode": query.get("bureau__code__in"),
+    "dangerPay": query.get("post__danger_pay__in"),
+    "gradeCode": query.get("grade__code__in"),
+    "languageCode": query.get("language_codes"),
+    # "organizationCode": "",
+    # "positionNumber": "",
+    "postDifferential": query.get("post__differential_rate__in"),
+    "skillCode": query.get("skill__code__in"),
+    "tourOfDutyCode": query.get("post__tour_of_duty__code__in")
+  }
+  return urlencode({i:j for i,j in values.items() if j is not None})
 
 def fsbid_pv_to_talentmap_pv(pv):
   return {

--- a/talentmap_api/fsbid/services.py
+++ b/talentmap_api/fsbid/services.py
@@ -1,6 +1,8 @@
 import requests
 import logging
 
+from datetime import datetime
+
 from urllib.parse import urlencode
 
 from django.conf import settings
@@ -121,10 +123,10 @@ def fsbid_pv_to_talentmap_pv(pv):
     },
     "current_assignment": {
       "user": pv["incumbent"],
-      "estimated_end_date": pv["ted"]
+      "estimated_end_date": datetime.strptime(pv["ted"], "%m/%Y")
     },
     "position_number": pv["position_number"],
-    "posted_date": pv["createDate"],
+    "posted_date": datetime.strptime(pv["createDate"], "%m-%d-%Y"),
     "title": pv["title"],
     "availability": {
       "availability": True,

--- a/talentmap_api/fsbid/services.py
+++ b/talentmap_api/fsbid/services.py
@@ -69,3 +69,77 @@ def fsbid_bid_to_talentmap_bid(data):
         }
       }
     }
+
+def get_projected_vacancies():
+  projected_vacancies = requests.get(f"{API_ROOT}/projectedVacancies").json()
+  return  map(fsbid_pv_to_talentmap_pv, projected_vacancies)
+
+def fsbid_pv_to_talentmap_pv(pv):
+  return {
+    "id": pv["pos_id"],
+    "grade": pv["grade"],
+    "skill": pv["skill"],
+    "bureau": pv["bureau"],
+    "organization": pv["organization"],
+    "tour_of_duty": pv["tour_of_duty"],
+    "languages": [
+      {
+        "language": pv["language1"],
+        "reading_proficiency": pv["reading_proficiency_1"],
+        "spoken_proficiency": pv["spoken_proficiency_1"],
+        "representation": pv["language_representation_1"]
+      }
+    ],
+    "post": {
+      "tour_of_duty": pv["tour_of_duty"],
+      "differential_rate": pv["differential_rate"],
+      "danger_pay": pv["danger_pay"],
+      "location": {
+        "id": 7,
+        "country": "United States",
+        "code": "171670031",
+        "city": "Chicago",
+        "state": "IL"
+      }
+    },
+    "current_assignment": {
+      "user": pv["incumbent"],
+      "estimated_end_date": pv["ted"]
+    },
+    "position_number": pv["position_number"],
+    "posted_date": pv["createDate"],
+    "title": pv["title"],
+    "availability": {
+      "availability": True,
+      "reason": ""
+    },
+    "bid_cycle_statuses": [
+      {
+        "id": pv["pos_id"],
+        "bidcycle": pv["bsn_descr_text"],
+        "position": "[D0144910] SPECIAL AGENT (Chicago, IL)",
+        "status_code": "OP",
+        "status": "Open"
+      }
+    ],
+    "bid_statistics": [
+      {
+        "id": pv["pos_id"],
+        "bidcycle": pv["bsn_descr_text"],
+        "total_bids": 0,
+        "in_grade": 0,
+        "at_skill": 0,
+        "in_grade_at_skill": 0,
+        "has_handshake_offered": False,
+        "has_handshake_accepted": False
+      }
+    ],
+    "latest_bidcycle": {
+      "id": 1,
+      "name": pv["bsn_descr_text"],
+      "cycle_start_date": "2018-08-15T19:17:30.065379Z",
+      "cycle_deadline_date": "2019-03-27T00:00:00Z",
+      "cycle_end_date": "2019-05-16T00:00:00Z",
+      "active": True
+    }
+  }

--- a/talentmap_api/fsbid/tests/test_fsbid_projected_vacancies.py
+++ b/talentmap_api/fsbid/tests/test_fsbid_projected_vacancies.py
@@ -22,9 +22,9 @@ pv = {
   "differential_rate": "0",
   "danger_pay": "N",
   "incumbent": "Test Incumbent",
-  "ted": "01/01/1000",
+  "ted": "01/1000",
   "position_number": "Test Position Number",
-  "createDate": "01/01/2000",
+  "createDate": "01-01-2000",
   "title": "Test Title",
   "bsn_descr_text": "Test Bid Season",
 

--- a/talentmap_api/fsbid/tests/test_fsbid_projected_vacancies.py
+++ b/talentmap_api/fsbid/tests/test_fsbid_projected_vacancies.py
@@ -1,0 +1,45 @@
+import pytest
+import datetime
+from dateutil.relativedelta import relativedelta
+from model_mommy import mommy
+from unittest.mock import Mock, patch
+from rest_framework import status
+from django.utils import timezone
+
+import talentmap_api.fsbid.services as services
+
+pv = {
+  "pos_id": "1",
+  "grade": "1",
+  "skill": "1",
+  "bureau": "Test Bureau",
+  "organization": "Test Org",
+  "tour_of_duty": "Test TED",
+  "language1": "Lang 1",
+  "reading_proficiency_1": "1",
+  "spoken_proficiency_1": "1",
+  "language_representation_1": "Lang Rep",
+  "differential_rate": "0",
+  "danger_pay": "N",
+  "incumbent": "Test Incumbent",
+  "ted": "01/01/1000",
+  "position_number": "Test Position Number",
+  "createDate": "01/01/2000",
+  "title": "Test Title",
+  "bsn_descr_text": "Test Bid Season",
+
+}
+
+@pytest.fixture
+def test_bidder_fixture(authorized_user):
+    group = mommy.make('auth.Group', name='bidder')
+    group.user_set.add(authorized_user)
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.usefixtures("test_bidder_fixture")
+def test_projected_vacancies_actions(authorized_client, authorized_user):
+   with patch('talentmap_api.fsbid.services.requests.get') as mock_get:
+      mock_get.return_value = Mock(ok=True)
+      mock_get.return_value.json.return_value = [pv]
+      response = authorized_client.get(f'/api/v1/fsbid/projected_vacancies')
+      assert response.json()[0]['id'] == [pv][0]['pos_id']

--- a/talentmap_api/fsbid/tests/test_fsbid_projected_vacancies.py
+++ b/talentmap_api/fsbid/tests/test_fsbid_projected_vacancies.py
@@ -24,7 +24,7 @@ pv = {
   "incumbent": "Test Incumbent",
   "ted": "01/1000",
   "position_number": "Test Position Number",
-  "createDate": "01-01-2000",
+  "createDate": "2000-01-01",
   "title": "Test Title",
   "bsn_descr_text": "Test Bid Season",
 
@@ -40,6 +40,6 @@ def test_bidder_fixture(authorized_user):
 def test_projected_vacancies_actions(authorized_client, authorized_user):
    with patch('talentmap_api.fsbid.services.requests.get') as mock_get:
       mock_get.return_value = Mock(ok=True)
-      mock_get.return_value.json.return_value = [pv]
+      mock_get.return_value.json.return_value = { "positions": [pv], "pagination": { "count": 0, "limit": 0 } }
       response = authorized_client.get(f'/api/v1/fsbid/projected_vacancies')
-      assert response.json()[0]['id'] == [pv][0]['pos_id']
+      assert response.json()["results"][0]['id'] == [pv][0]['pos_id']

--- a/talentmap_api/fsbid/urls/projected_vacancies.py
+++ b/talentmap_api/fsbid/urls/projected_vacancies.py
@@ -1,0 +1,12 @@
+from django.conf.urls import url
+from rest_framework import routers
+
+from talentmap_api.fsbid.views import projected_vacancies as views
+
+router = routers.SimpleRouter()
+
+urlpatterns = [
+    url(r'', views.FSBidProjectedVacanciesListView.as_view(), name="projected-vacancies-FSBid-projected-vacancies-actions"),
+]
+
+urlpatterns += router.urls

--- a/talentmap_api/fsbid/views/projected_vacancies.py
+++ b/talentmap_api/fsbid/views/projected_vacancies.py
@@ -1,0 +1,33 @@
+from dateutil.relativedelta import relativedelta
+
+from django.shortcuts import get_object_or_404
+from django.core.exceptions import PermissionDenied
+from django.utils import timezone
+
+from rest_framework.viewsets import GenericViewSet
+from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
+
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+
+from talentmap_api.user_profile.models import UserProfile
+
+import talentmap_api.fsbid.services as services
+
+import logging
+logger = logging.getLogger(__name__)
+
+class FSBidProjectedVacanciesListView(APIView):
+
+    permission_classes = (IsAuthenticatedOrReadOnly,)
+
+    @classmethod
+    def get_extra_actions(cls):
+        return []
+
+    def get(self, request, *args, **kwargs):
+        '''
+        Gets all projected vacancies
+        '''
+        return Response(services.get_projected_vacancies())

--- a/talentmap_api/fsbid/views/projected_vacancies.py
+++ b/talentmap_api/fsbid/views/projected_vacancies.py
@@ -30,4 +30,4 @@ class FSBidProjectedVacanciesListView(APIView):
         '''
         Gets all projected vacancies
         '''
-        return Response(services.get_projected_vacancies(request.query_params))
+        return Response(services.get_projected_vacancies(request.query_params, f"{request.scheme}://{request.get_host()}"))

--- a/talentmap_api/fsbid/views/projected_vacancies.py
+++ b/talentmap_api/fsbid/views/projected_vacancies.py
@@ -30,4 +30,4 @@ class FSBidProjectedVacanciesListView(APIView):
         '''
         Gets all projected vacancies
         '''
-        return Response(services.get_projected_vacancies())
+        return Response(services.get_projected_vacancies(request.query_params))

--- a/talentmap_api/urls.py
+++ b/talentmap_api/urls.py
@@ -37,6 +37,7 @@ urlpatterns = [
 
     # FSBId
     url(r'^api/v1/fsbid/bidlist/', include('talentmap_api.fsbid.urls.bidlist')),
+    url(r'^api/v1/fsbid/projected_vacancies', include('talentmap_api.fsbid.urls.projected_vacancies')),
 
     # Language and language related resources
     url(r'^api/v1/language/', include('talentmap_api.language.urls.languages')),


### PR DESCRIPTION
Basic outline for TM-643. Just gets all the projected vacancies from the mock api and returns the list.

Builds on feature/fsbid-get-bids branch. See #57.