### PR TITLE
adding ordering to client queryset to address pagination duplicates

### DIFF
--- a/talentmap_api/user_profile/views/client.py
+++ b/talentmap_api/user_profile/views/client.py
@@ -47,7 +47,7 @@ class CdoClientView(ActionDependentSerializerMixin,
     permission_classes = (IsAuthenticated,)
 
     def get_queryset(self):
-        return get_prefetched_filtered_queryset(UserProfile, self.serializer_class, cdo=self.request.user.profile)
+        return get_prefetched_filtered_queryset(UserProfile, self.serializer_class, cdo=self.request.user.profile).order_by("id")
 
 
 class CdoClientStatisticsView(APIView):


### PR DESCRIPTION
Ordering by anything fixes the pagination duplicates. Talked with Mike and ordering by ID makes the most sense.