### PR TITLE
Add obc_id to PositionList serializer

### DIFF
--- a/talentmap_api/position/serializers.py
+++ b/talentmap_api/position/serializers.py
@@ -187,6 +187,7 @@ class PositionListSerializer(PrefetchedSerializer):
                         "danger_pay",
                         "location",
                         "tour_of_duty",
+                        "obc_id",
                     ],
                     "many": False,
                     "read_only": True


### PR DESCRIPTION
For some reason this was not included in the PositionList serializer, resulting in OBC links not being displayed on the Compare page.