### PR TITLE
update latest_bid_cycle to only include active cycles

### DIFF
--- a/talentmap_api/bidding/models.py
+++ b/talentmap_api/bidding/models.py
@@ -300,6 +300,18 @@ def bidcycle_positions_update(sender, instance, action, reverse, model, pk_set, 
                 pos.latest_bidcycle = None
             pos.save()
 
+@receiver(post_save, sender=BidCycle, dispatch_uid="bidcycle_active_changed")
+def bidcycle_active_changed(sender, instance, **kwargs):
+    '''
+    Update positions latest_active_bidcycle field to latest acive bidcycle
+    '''
+    positions = talentmap_api.position.models.Position.objects.filter(id__in=instance.positions.values_list('id', flat=True))
+    for pos in positions:
+        if pos.bid_cycles.filter(active=True).count() > 0:
+            pos.latest_bidcycle = pos.bid_cycles.filter(active=True).latest('cycle_start_date')
+        else:
+            pos.latest_bidcycle = None
+        pos.save()
 
 @receiver(pre_save, sender=Bid, dispatch_uid="bid_status_changed")
 def bid_status_changed(sender, instance, **kwargs):

--- a/talentmap_api/bidding/models.py
+++ b/talentmap_api/bidding/models.py
@@ -294,8 +294,8 @@ def bidcycle_positions_update(sender, instance, action, reverse, model, pk_set, 
     if action in ["post_add", "post_remove"]:
         for position_id in pk_set:
             pos = talentmap_api.position.models.Position.objects.get(pk=position_id)
-            if pos.bid_cycles.count() > 0:
-                pos.latest_bidcycle = pos.bid_cycles.latest('cycle_start_date')
+            if pos.bid_cycles.filter(active=True).count() > 0:
+                pos.latest_bidcycle = pos.bid_cycles.filter(active=True).latest('cycle_start_date')
             else:
                 pos.latest_bidcycle = None
             pos.save()

--- a/talentmap_api/position/serializers.py
+++ b/talentmap_api/position/serializers.py
@@ -187,6 +187,7 @@ class PositionListSerializer(PrefetchedSerializer):
                         "danger_pay",
                         "location",
                         "tour_of_duty",
+                        "obc_id",
                     ],
                     "many": False,
                     "read_only": True


### PR DESCRIPTION
only include active cycles in cycles considered when updating the latest_bidding_cycle field on a position. Also, added a function to run this same situation on all positions in the cycle when the status of the cycle changes.