### PR TITLE
Filter out cyclepositions that have a null posted_date

### DIFF
--- a/talentmap_api/bidding/views/cycleposition.py
+++ b/talentmap_api/bidding/views/cycleposition.py
@@ -43,7 +43,7 @@ class CyclePositionListView(FieldLimitableSerializerMixin,
     permission_classes = (IsAuthenticatedOrReadOnly,)
 
     def get_queryset(self):
-        queryset = CyclePosition.objects.filter(bidcycle__active=True, status_code__in=["HS", "OP"])
+        queryset = CyclePosition.objects.filter(bidcycle__active=True, status_code__in=["HS", "OP"], posted_date__isnull=False)
         queryset = self.serializer_class.prefetch_model(CyclePosition, queryset)
         return queryset
 


### PR DESCRIPTION
Resolves part of discrepancy between FSBid and TalentMAP count