### PR TITLE
fix: allow multiple filter values to be sent to fsbid as the same param. Addresses TM-1203 TM-1204 TM-1206

### DIFF
--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -22,3 +22,7 @@ def get_pagination(query, count, base_url, host=None):
         "next": next_url,
         "previous": previous_url
     }
+
+def convert_multi_value(val):
+    if val is not None:
+        return val.split(',')

--- a/talentmap_api/fsbid/services/projected_vacancies.py
+++ b/talentmap_api/fsbid/services/projected_vacancies.py
@@ -186,5 +186,4 @@ def convert_pv_query(query):
         "fv_request_params.pos_numbers": services.convert_multi_value(query.get("position__position_number__in", None)),
         "fv_request_params.seq_nums": services.convert_multi_value(query.get("id", None)),
     }
-    print(values.items())
     return urlencode({i: j for i, j in values.items() if j is not None}, doseq=True)

--- a/talentmap_api/fsbid/services/projected_vacancies.py
+++ b/talentmap_api/fsbid/services/projected_vacancies.py
@@ -142,7 +142,7 @@ def post_values(query):
         location_codes = Post.objects.filter(id__in=post_ids).values_list("_location_code", flat=True)
         results = results + list(location_codes)
     if len(results) > 0:
-        return ",".join(results)
+        return results
 
 def bureau_values(query):
     '''
@@ -162,7 +162,7 @@ def bureau_values(query):
         reg_org_codes = Organization.objects.filter(Q(code__in=regional_bureaus) | Q(_parent_organization_code__in=regional_bureaus)).values_list("code", flat=True)
         results = results + list(reg_org_codes)
     if len(results) > 0:
-        return ",".join(results)
+        return results
 
 def convert_pv_query(query):
     '''
@@ -174,16 +174,17 @@ def convert_pv_query(query):
         "fv_request_params.page_index": int(query.get("page", 1)),
         "fv_request_params.page_size": query.get("limit", 25),
         "fv_request_params.freeText": query.get("q", None),
-        "fv_request_params.bid_seasons": query.get("is_available_in_bidseason"),
+        "fv_request_params.bid_seasons": services.convert_multi_value(query.get("is_available_in_bidseason")),
         "fv_request_params.bureaus": bureau_values(query),
-        "fv_request_params.danger_pays": query.get("position__post__danger_pay__in"),
-        "fv_request_params.grades": query.get("position__grade__code__in"),
-        "fv_request_params.languages": query.get("language_codes"),
-        "fv_request_params.differential_pays": query.get("position__post__differential_rate__in"),
-        "fv_request_params.skills": query.get("position__skill__code__in"),
-        "fv_request_params.tod_codes": query.get("position__post__tour_of_duty__code__in"),
+        "fv_request_params.danger_pays": services.convert_multi_value(query.get("position__post__danger_pay__in")),
+        "fv_request_params.grades": services.convert_multi_value(query.get("position__grade__code__in")),
+        "fv_request_params.languages": services.convert_multi_value(query.get("language_codes")),
+        "fv_request_params.differential_pays": services.convert_multi_value(query.get("position__post__differential_rate__in")),
+        "fv_request_params.skills": services.convert_multi_value(query.get("position__skill__code__in")),
+        "fv_request_params.tod_codes": services.convert_multi_value(query.get("position__post__tour_of_duty__code__in")),
         "fv_request_params.location_codes": post_values(query),
-        "fv_request_params.pos_numbers": query.get("position__position_number__in", None),
-        "fv_request_params.seq_nums": query.get("id", None),
+        "fv_request_params.pos_numbers": services.convert_multi_value(query.get("position__position_number__in", None)),
+        "fv_request_params.seq_nums": services.convert_multi_value(query.get("id", None)),
     }
-    return urlencode({i: j for i, j in values.items() if j is not None})
+    print(values.items())
+    return urlencode({i: j for i, j in values.items() if j is not None}, doseq=True)


### PR DESCRIPTION
rather than send comma separated values for a param, send params as multiple keys in query string. 
so 
`fv_request_params.seq_nums=1,2,3` 
becomes `fv_request_params.seq_nums=1&fv_request_params.seq_nums=2&fv_request_params.seq_nums=3`