### PR TITLE
chore: allow for jwt to be set for swagger calls via authorize

### DIFF
--- a/talentmap_api/settings.py
+++ b/talentmap_api/settings.py
@@ -490,3 +490,14 @@ CORS_ALLOW_HEADERS = [
 'x-csrftoken',
 'x-requested-with',
 ]
+
+SWAGGER_SETTINGS = {
+    'SECURITY_DEFINITIONS': {
+        "api_key": {
+            "type": "apiKey",
+            "name": "JWT",
+            "in": "header",
+            "description": "JWT authorization"
+        },
+    },
+}


### PR DESCRIPTION
Click on the Authorize button in the header of the Swagger site and enter something into the jwt box. This will send that header with requests so all the endpoints that require JWT can be tested via swagger