### PR TITLE
feature: capture ids as a filter used in comparison

### DIFF
--- a/talentmap_api/fsbid/views/available_positions.py
+++ b/talentmap_api/fsbid/views/available_positions.py
@@ -38,6 +38,7 @@ class FSBidAvailablePositionsListView(BaseView):
             coreapi.Field("position__post__differential_rate__in", location='query', description='Diff. Rate'),
             coreapi.Field("language_codes", location='query', description='Language code'),
             coreapi.Field("position__post__danger_pay__in", location='query', description='Danger pay'),
+            coreapi.Field("id", location="query", description="Available Position ids"),
             coreapi.Field("q", location='query', description='Text search'),
         ]
     )

--- a/talentmap_api/fsbid/views/projected_vacancies.py
+++ b/talentmap_api/fsbid/views/projected_vacancies.py
@@ -39,6 +39,7 @@ class FSBidProjectedVacanciesListView(BaseView):
             coreapi.Field("position__post__differential_rate__in", location='query', description='Diff. Rate'),
             coreapi.Field("language_codes", location='query', description='Language code'),
             coreapi.Field("position__post__danger_pay__in", location='query', description='Danger pay'),
+            coreapi.Field("id", location="query", description="Projected Vacancies ids"),
         ]
     )
 


### PR DESCRIPTION
adds id comma separated filter capabilities used in the comparison. needed for https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/433

use the following urls...

`/api/v1/fsbid/availablePositions?id=1,2`
`/api/v1/fsbid/projectedVacancies?id=1,2`

swagger also has id field that accepts comma separated string for multiple values