### PR TITLE
fix: allow sorting on posted_date. TM-1337

### DIFF
--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -109,7 +109,8 @@ sort_dict = {
     "position__grade": "pos_grade_code",
     "position__bureau": "pos_bureau_short_desc",
     "ted": "ted",
-    "position__position_number": "pos_num_text"
+    "position__position_number": "pos_num_text",
+    "posted_date": "cp_post_dt"
 }
 
 


### PR DESCRIPTION
adds posted date as a valid sort option