### PR TITLE
chore: add debug env value

### DIFF
--- a/docker-compose.local-fsbid.yml
+++ b/docker-compose.local-fsbid.yml
@@ -20,5 +20,6 @@ services:
       - DB_PASSWORD=fsbid_pwd
       - DB_PORT=5432
       - DB_CHARSET=utf8
+      - DEBUG=false
 volumes:
   mock_pgdata:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -19,4 +19,6 @@ services:
       - DB_PASSWORD=fsbid_pwd
       - DB_PORT=5432
       - DB_CHARSET=utf8
+      - DEBUG=false
+
 


### PR DESCRIPTION
turns off the debugging of the sql in the mock by default