### PR TITLE
chore: use a correct volumne for mock db

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,10 +28,11 @@ services:
   mock_db:
     image: postgres:9.6.3
     volumes:
-      - pgdata:/var/lib/postgresql/mock-data/
+      - mock-pgdata:/var/lib/postgresql/data/
     environment:
       - POSTGRES_DB=mockfsbid
       - POSTGRES_USER=mockfsbid-user
       - POSTGRES_PASSWORD=fsbid_pwd
 volumes:
   pgdata:
+  mock-pgdata:


### PR DESCRIPTION
keeps the database around between builds and other activities