### PR TITLE
Fix the requested position id being included in similar position results

### DIFF
--- a/talentmap_api/fsbid/services/available_positions.py
+++ b/talentmap_api/fsbid/services/available_positions.py
@@ -129,12 +129,15 @@ def get_available_positions_csv(query, jwt_token, host=None):
         ])
     return response
 
-# Max number of similar positions to return
+# Max number of similar positions to return.
 SIMILAR_LIMIT = 3
 
 # Filters available positions by the criteria provides and by the position with the provided id
 def filter_available_positions_exclude_self(id, criteria, jwt_token, host):
-    return list(filter(lambda i: str(id) != str(i["id"]), get_available_positions({**criteria, **{"limit":SIMILAR_LIMIT}}, jwt_token, host)["results"]))
+    # Add 1 to the limit, since we'll be filtering out positions that match id
+    a = list(filter(lambda i: float(id) != i["id"], get_available_positions({**criteria, **{"limit":SIMILAR_LIMIT + 1}}, jwt_token, host)["results"]))
+    # Ensure we only return the limit, at most
+    return a[:SIMILAR_LIMIT]
 
 def get_similar_available_positions(id, jwt_token, host=None):
     '''


### PR DESCRIPTION
`cp_id`s are getting mapped in the format of `10901.0` causing them not to match a similar position id in the format of `10901`. This converts the source id to a float to ensure that the position id is filtered out from the similar results. This also fixes the fact that when the requested id is filtered out, we are missing out on one additional result in the request.

We should look into ensuring that ids aren't coming through as floats, as I've also seen that in response payloads.