### PR TITLE
Return the CDO of the user from FSBid

### DIFF
--- a/talentmap_api/fsbid/services/cdo.py
+++ b/talentmap_api/fsbid/services/cdo.py
@@ -3,6 +3,7 @@ import logging
 import jwt
 import talentmap_api.fsbid.services.common as services
 from django.conf import settings
+from talentmap_api.common.common_helpers import get_avatar_url
 
 API_ROOT = settings.FSBID_API_URL
 
@@ -17,6 +18,21 @@ def cdo(jwt_token):
     uri = f"Agents?ad_id={ad_id}&rl_cd=CDO"
     response = services.get_fsbid_results(uri, jwt_token, fsbid_cdo_list_to_talentmap_cdo_list, email)
     return response
+
+def single_cdo(jwt_token = None, perdet_seq_num = None):
+    '''
+    Get a single client for a CDO
+    '''
+    ad_id = jwt.decode(jwt_token, verify=False).get('unique_name')
+    email = jwt.decode(jwt_token, verify=False).get('email')
+    uri = f"Agents?ad_id={ad_id}&rl_cd=CDO&request_params.perdet_seq_num={perdet_seq_num}"
+    response = services.get_fsbid_results(uri, jwt_token, fsbid_cdo_list_to_talentmap_cdo_list, email)
+    cdo = list(response)[0]
+    initials = "".join([x for x in cdo['email'] if x.isupper()][:2][::-1])
+    cdo['initials'] = initials
+    avatar = get_avatar_url(cdo['email'])
+    cdo['avatar'] = avatar
+    return cdo
 
 def fsbid_cdo_list_to_talentmap_cdo_list(data):
     return {

--- a/talentmap_api/fsbid/services/client.py
+++ b/talentmap_api/fsbid/services/client.py
@@ -2,6 +2,7 @@ import requests
 import logging
 import jwt
 import talentmap_api.fsbid.services.common as services
+import talentmap_api.fsbid.services.cdo as cdo_services
 import talentmap_api.fsbid.services.available_positions as services_ap
 import csv
 from copy import deepcopy
@@ -91,7 +92,10 @@ def single_client(jwt_token, perdet_seq_num):
     ad_id = jwt.decode(jwt_token, verify=False).get('unique_name')
     uri = f"CDOClients?request_params.ad_id={ad_id}&request_params.perdet_seq_num={perdet_seq_num}"
     response = services.get_fsbid_results(uri, jwt_token, fsbid_clients_to_talentmap_clients)
-    return list(response)[0]
+    cdo = cdo_services.single_cdo(jwt_token, perdet_seq_num)
+    client = list(response)[0]
+    client['cdo'] = cdo
+    return client
 
 def get_client_csv(query, jwt_token, rl_cd, host=None):
     ad_id = jwt.decode(jwt_token, verify=False).get('unique_name')

--- a/talentmap_api/fsbid/urls/cdo.py
+++ b/talentmap_api/fsbid/urls/cdo.py
@@ -9,6 +9,7 @@ urlpatterns = [
     url(r'^position/(?P<pk>[0-9]+)/client/(?P<client_id>[0-9]+)/$', views.FSBidListPositionActionView.as_view(), name='cdo-bidding.FSBid-position-actions'),
     url(r'^position/(?P<pk>[0-9]+)/client/(?P<client_id>[0-9]+)/submit/$', views.FSBidListBidActionView.as_view(), name='cdo-bidding.FSBid-bid-actions'),
     url(r'^client/(?P<client_id>[0-9]+)/$', views.FSBidListView.as_view(), name="cdo-bidding-FSBid-bid-actions"),
+    url(r'^(?P<pk>[0-9]+)/$', views.FSBidCDOView.as_view(), name='FSBid-cdo'),
     url(r'^$', views.FSBidCDOListView.as_view(), name='FSBid-cdo_list'),
 ]
 

--- a/talentmap_api/fsbid/views/cdo.py
+++ b/talentmap_api/fsbid/views/cdo.py
@@ -22,6 +22,15 @@ class FSBidCDOListView(BaseView):
         return Response(cdoServices.cdo(request.META['HTTP_JWT']))
 
 
+class FSBidCDOView(BaseView):
+
+    def get(self, request, pk):
+        '''
+        Gets a single cdo by client's perdet_seq_num
+        '''
+        return Response(cdoServices.single_cdo(request.META['HTTP_JWT'], pk))
+
+
 class FSBidListView(BaseView):
 
     permission_classes = (IsAuthenticated, isDjangoGroupMember('cdo'),)

--- a/talentmap_api/user_profile/models.py
+++ b/talentmap_api/user_profile/models.py
@@ -22,8 +22,6 @@ class UserProfile(StaticRepresentationModel):
     mandatory_retirement_date = models.DateTimeField(null=True)
     phone_number = models.TextField(null=True)
 
-    cdo = models.ForeignKey('self', on_delete=models.DO_NOTHING, related_name='direct_reports', null=True)
-
     language_qualifications = models.ManyToManyField('language.Qualification', related_name='qualified_users')
 
     skills = models.ManyToManyField('position.Skill')

--- a/talentmap_api/user_profile/models.py
+++ b/talentmap_api/user_profile/models.py
@@ -22,6 +22,8 @@ class UserProfile(StaticRepresentationModel):
     mandatory_retirement_date = models.DateTimeField(null=True)
     phone_number = models.TextField(null=True)
 
+    cdo = models.ForeignKey('self', on_delete=models.DO_NOTHING, related_name='direct_reports', null=True)
+
     language_qualifications = models.ManyToManyField('language.Qualification', related_name='qualified_users')
 
     skills = models.ManyToManyField('position.Skill')

--- a/talentmap_api/user_profile/serializers.py
+++ b/talentmap_api/user_profile/serializers.py
@@ -53,12 +53,11 @@ class UserProfileShortSerializer(PrefetchedSerializer):
     email = serializers.CharField(source="user.email")
     initials = serializers.ReadOnlyField()
     avatar = serializers.ReadOnlyField()
-    cdo = serializers.ReadOnlyField()
     display_name = serializers.ReadOnlyField()
 
     class Meta:
         model = UserProfile
-        fields = ["username", "first_name", "last_name", "email", "phone_number", "is_cdo", "initials", "avatar", "cdo", "display_name"]
+        fields = ["username", "first_name", "last_name", "email", "phone_number", "is_cdo", "initials", "avatar", "display_name"]
 
 
 class ClientSerializer(PrefetchedSerializer):

--- a/talentmap_api/user_profile/serializers.py
+++ b/talentmap_api/user_profile/serializers.py
@@ -186,7 +186,7 @@ class UserProfileWritableSerializer(PrefetchedSerializer):
 
     class Meta:
         model = UserProfile
-        fields = ["language_qualifications", "favorite_positions", "primary_nationality", "secondary_nationality", "date_of_birth", "phone_number", "initials", "avatar", "cdo", "display_name"]
+        fields = ["language_qualifications", "favorite_positions", "primary_nationality", "secondary_nationality", "date_of_birth", "phone_number", "initials", "avatar", "display_name"]
         writable_fields = ("language_qualifications", "favorite_positions", "primary_nationality", "secondary_nationality", "date_of_birth", "phone_number")
 
 

--- a/talentmap_api/user_profile/serializers.py
+++ b/talentmap_api/user_profile/serializers.py
@@ -72,7 +72,7 @@ class ClientSerializer(PrefetchedSerializer):
 
     class Meta:
         model = UserProfile
-        fields = ["id", "skills", "grade", "is_cdo", "primary_nationality", "secondary_nationality", "bid_statistics", "user", "language_qualifications", "initials", "avatar", "cdo", "display_name"]
+        fields = ["id", "skills", "grade", "is_cdo", "primary_nationality", "secondary_nationality", "bid_statistics", "user", "language_qualifications", "initials", "avatar", "display_name"]
         nested = {
             "user": {
                 "class": UserSerializer,

--- a/talentmap_api/user_profile/serializers.py
+++ b/talentmap_api/user_profile/serializers.py
@@ -136,9 +136,13 @@ class UserProfileSerializer(PrefetchedSerializer):
 
     def get_cdo(self, obj):
         request = self.context['request']
-        jwt = request.META['HTTP_JWT']
-        user = UserProfile.objects.get(user=request.user)
-        return single_cdo(jwt, user.emp_id)
+        try:
+            jwt = request.META['HTTP_JWT']
+            user = UserProfile.objects.get(user=request.user)
+            return single_cdo(jwt, user.emp_id)
+        except:
+            return None
+
 
     class Meta:
         model = UserProfile


### PR DESCRIPTION
This is not fully functioning since our mock is not updated, but the /Agents endpoint should be able to accept a `perdet_seq_num` query parameter, so that the agent of a client with a given perdet can be retrieved. This performs that lookup and adds the response to the UserProfile and Client responses.