### PR TITLE
TM-1566 - feature: add sorting for the cdo clients endpoint

### DIFF
--- a/talentmap_api/fsbid/services/client.py
+++ b/talentmap_api/fsbid/services/client.py
@@ -16,22 +16,13 @@ API_ROOT = settings.FSBID_API_URL
 
 logger = logging.getLogger(__name__)
 
-def client(jwt_token, hru_id, rl_cd, hasHandshake, q):
+def client(jwt_token, query):
     '''
     Get Clients by CDO
     '''
     ad_id = jwt.decode(jwt_token, verify=False).get('unique_name')
-    uri = f"CDOClients?request_params.ad_id={ad_id}"
-    if hru_id:
-        uri = uri + f'&request_params.hru_id={hru_id}'
-    if rl_cd:
-        uri = uri + f'&request_params.rl_cd={rl_cd}'
-    if hasHandshake:
-        # Convert Front end request of true/false to Y/N for FSBid
-        hs_cd = tmap_handshake_to_fsbid(hasHandshake)
-        uri = uri + f'&request_params.hs_cd={hs_cd}'
-    if q:
-        uri = uri + f'&request_params.freeText={q}'
+    uri = f"CDOClients?request_params.ad_id={ad_id}&{convert_client_query(query)}"
+    print(uri)
     response = services.get_fsbid_results(uri, jwt_token, fsbid_clients_to_talentmap_clients)
     return response
 

--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -133,7 +133,9 @@ sort_dict = {
     "position__bureau": "pos_bureau_short_desc",
     "ted": "ted",
     "position__position_number": "pos_num_text",
-    "posted_date": "cp_post_dt"
+    "posted_date": "cp_post_dt",
+    "skill": "skill",
+    "grade": "grade",
 }
 
 

--- a/talentmap_api/fsbid/views/client.py
+++ b/talentmap_api/fsbid/views/client.py
@@ -20,14 +20,15 @@ class FSBidClientListView(BaseView):
             coreapi.Field("hru_id", location='query', description='HRU id of the Agent'),
             coreapi.Field("rl_cd", location='query', description='Role code of the Agent'),
             coreapi.Field("hasHandshake", location='query', description='True or False filter for clients with any offered handshakes'),
-            coreapi.Field("q", location='query', description='Free Text')
+            coreapi.Field("q", location='query', description='Free Text'),
+            coreapi.Field("ordering", location='query', description='Which field to use when ordering the results.')
         ]
     )
     def get(self, request):
         '''
         Gets all clients for a CDO
         '''
-        return Response(services.client(request.META['HTTP_JWT'], request.query_params.get('hru_id'), request.query_params.get('rl_cd'), request.query_params.get('hasHandshake'), request.query_params.get('q')))
+        return Response(services.client(request.META['HTTP_JWT'], request.query_params))
 
 
 


### PR DESCRIPTION
sort on grade or skill or send both using the python - syntax for direction. The implementation of the field names may change based on FSBid but none of the computers have DevNet so i can't check it. The mock currently accepts params grade and skill for testing purposes