### PR TITLE
Add parameters for exporting favorites

### DIFF
--- a/talentmap_api/available_positions/views/available_position.py
+++ b/talentmap_api/available_positions/views/available_position.py
@@ -1,3 +1,5 @@
+import coreapi
+
 from django.shortcuts import get_object_or_404
 from django.http import QueryDict
 
@@ -6,6 +8,7 @@ from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnl
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status, mixins
+from rest_framework.schemas import AutoSchema
 
 from talentmap_api.common.common_helpers import in_group_or_403
 from talentmap_api.common.mixins import FieldLimitableSerializerMixin
@@ -17,6 +20,17 @@ from talentmap_api.projected_vacancies.models import ProjectedVacancyFavorite
 import talentmap_api.fsbid.services.available_positions as services
 import talentmap_api.fsbid.services.projected_vacancies as pvservices
 import talentmap_api.fsbid.services.common as comservices
+
+class AvailablePositionsFilter():
+    declared_filters = [
+        "exclude_available",
+        "exclude_projected",
+    ]
+
+    use_api = True
+
+    class Meta:
+        fields = "__all__"
 
 class AvailablePositionFavoriteListView(APIView):
 
@@ -38,25 +52,33 @@ class AvailablePositionFavoriteListView(APIView):
 class FavoritesCSVView(APIView):
 
     permission_classes = (IsAuthenticated,)
+    filter_class = AvailablePositionsFilter
+
+    schema = AutoSchema(
+        manual_fields=[
+            coreapi.Field("exclude_available", type='boolean', location='query', description='Whether to exclude available positions'),
+            coreapi.Field("exclude_projected", type='boolean', location='query', description='Whether to exclude projected vacancies'),
+        ]
+    )
 
     def get(self, request, *args, **kwargs):
         """
         Return a list of all of the user's favorite positions.
         """
         user = UserProfile.objects.get(user=self.request.user)
-        apdata = pvdata = []
+        data = []
 
         aps = AvailablePositionFavorite.objects.filter(user=user).values_list("cp_id", flat=True)
-        if len(aps) > 0:
+        if len(aps) > 0 and request.query_params.get('exclude_available') != 'true':
             pos_nums = ','.join(aps)
             apdata = services.get_available_positions(QueryDict(f"id={pos_nums}"), request.META['HTTP_JWT'])
-            
+            data = data + apdata.get('results')
+
         pvs = ProjectedVacancyFavorite.objects.filter(user=user).values_list("fv_seq_num", flat=True)
-        if len(pvs) > 0:
+        if len(pvs) > 0 and request.query_params.get('exclude_projected') != 'true':
             pos_nums = ','.join(pvs)
             pvdata = pvservices.get_projected_vacancies(QueryDict(f"id={pos_nums}"), request.META['HTTP_JWT'])
-        
-        data = apdata.get('results') + pvdata.get('results')
+            data = data + pvdata.get('results')
 
         return comservices.get_ap_and_pv_csv(data, "favorites", True)
 


### PR DESCRIPTION
Add parameters when exporting favorites to `?exclude_available` positions and/or `?exclude_projected` vacancies.