### PR TITLE
Additional ordering mapping

### DIFF
--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -136,6 +136,8 @@ sort_dict = {
     "posted_date": "cp_post_dt",
     "skill": "skill",
     "grade": "grade",
+    "client_skill": "per_skill_code",
+    "client_grade": "per_grade_code",
 }
 
 


### PR DESCRIPTION
Add new ordering mappings for /CDOClients. Causes uncaught error with mock