### PR TITLE
Add routes to fetch only the IDs of the user's favorite positions

### DIFF
--- a/talentmap_api/available_positions/urls/available_positions.py
+++ b/talentmap_api/available_positions/urls/available_positions.py
@@ -10,6 +10,7 @@ router = routers.SimpleRouter()
 urlpatterns = [
     url(r'^favorites/export/$', views.FavoritesCSVView.as_view(), name='export-all-favorites'),
     url(r'^favorites/$', views.AvailablePositionFavoriteListView.as_view(), name='view-favorite-available-positions'),
+    url(r'^favorites/ids/$', views.AvailablePositionFavoriteIdsListView.as_view(), name='view-favorite-available-positions-ids'),
     url(r'^(?P<pk>[0-9]+)/favorite/$', views.AvailablePositionFavoriteActionView.as_view(), name='available_positions-AvailablePositionFavorite-favorite'),
     url(r'^(?P<pk>[0-9]+)/designation/$', views.AvailablePositionDesignationView.as_view({ **patch_update }), name='available_positions-AvailablePositionDesignation-designation'),
     url(r'^highlight/$', views.AvailablePositionHighlightListView.as_view(), name='view-highlighted-availablepositions'),

--- a/talentmap_api/available_positions/views/available_position.py
+++ b/talentmap_api/available_positions/views/available_position.py
@@ -49,6 +49,19 @@ class AvailablePositionFavoriteListView(APIView):
         else:
             return Response({"count": 0, "next": None, "previous": None, "results": []})
 
+class AvailablePositionFavoriteIdsListView(APIView):
+
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request, *args, **kwargs):
+        """
+        get:
+        Return a list of the ids of the user's favorite available positions.
+        """
+        user = UserProfile.objects.get(user=self.request.user)
+        aps = AvailablePositionFavorite.objects.filter(user=user).values_list("cp_id", flat=True)
+        return Response(aps)
+
 class FavoritesCSVView(APIView):
 
     permission_classes = (IsAuthenticated,)

--- a/talentmap_api/projected_vacancies/urls/projected_vacancies.py
+++ b/talentmap_api/projected_vacancies/urls/projected_vacancies.py
@@ -9,6 +9,7 @@ router = routers.SimpleRouter()
 
 urlpatterns = [
     url(r'^favorites/$', views.ProjectedVacancyFavoriteListView.as_view(), name='view-favorite-projected-vacancies'),
+    url(r'^favorites/ids/$', views.ProjectedVacancyFavoriteIdsListView.as_view(), name='view-favorite-projected-vacancies-ids'),
     url(r'^(?P<pk>[0-9]+)/favorite/$', views.ProjectedVacancyFavoriteActionView.as_view(), name='projected_vacancies-ProjectedVacancyFavorite-favorite'),
 ]
 

--- a/talentmap_api/projected_vacancies/views/projected_vacancy.py
+++ b/talentmap_api/projected_vacancies/views/projected_vacancy.py
@@ -32,6 +32,19 @@ class ProjectedVacancyFavoriteListView(APIView):
         else:
             return Response({"count": 0, "next": None, "previous": None, "results": []})
 
+class ProjectedVacancyFavoriteIdsListView(APIView):
+
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request, *args, **kwargs):
+        """
+        get:
+        Return a list of the ids of the user's favorite projected vacancies.
+        """
+        user = UserProfile.objects.get(user=self.request.user)
+        pvs = ProjectedVacancyFavorite.objects.filter(user=user).values_list("fv_seq_num", flat=True)
+        return Response(pvs)
+
 
 class ProjectedVacancyFavoriteActionView(APIView):
     '''


### PR DESCRIPTION
Return a simple list of the IDs of the user's favorites (`["1", "5", "101", ...]`). Will be used with a front-end PR to improve the the load time after adding/removing a favorite. This PR can be merged before that.