### PR TITLE
Bump MarkupSafe requirement to avoid build error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ itypes==1.1.0
 Jinja2==2.10.1
 locustio==0.8.1
 lxml==4.2.1
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 maya==0.6.1
 model-mommy==1.5.1
 more-itertools==4.1.0


### PR DESCRIPTION
Bumps this requirement to get rid of a build error in local docker setup