### PR TITLE
Add internal/external employee profile URLs

### DIFF
--- a/talentmap_api/fsbid/services/client.py
+++ b/talentmap_api/fsbid/services/client.py
@@ -228,7 +228,7 @@ def fsbid_clients_to_talentmap_clients(data):
         "classifications": fsbid_classifications_to_tmap(employee.get("classifications", [])),
         "current_assignment": current_assignment,
         "assignments": fsbid_assignments_to_tmap(assignments),
-        "employee_profile_url": services.get_employee_profile_urls(employee.get("pert_external_id", None)),
+        "employee_profile_url": services.get_employee_profile_urls(employee.get("perdet_seq_num", None)),
     }
 
 

--- a/talentmap_api/fsbid/services/client.py
+++ b/talentmap_api/fsbid/services/client.py
@@ -16,6 +16,8 @@ import talentmap_api.fsbid.services.available_positions as services_ap
 from talentmap_api.common.common_helpers import ensure_date
 
 API_ROOT = settings.FSBID_API_URL
+HRDATA_URL = settings.HRDATA_URL
+HRDATA_URL_EXTERNAL = settings.HRDATA_URL_EXTERNAL
 
 logger = logging.getLogger(__name__)
 
@@ -225,7 +227,8 @@ def fsbid_clients_to_talentmap_clients(data):
         "hasHandshake": fsbid_handshake_to_tmap(data.get("hs_cd")),
         "classifications": fsbid_classifications_to_tmap(employee.get("classifications", [])),
         "current_assignment": current_assignment,
-        "assignments": fsbid_assignments_to_tmap(assignments)
+        "assignments": fsbid_assignments_to_tmap(assignments),
+        "employee_profile_url": services.get_employee_profile_urls(employee.get("pert_external_id", None)),
     }
 
 

--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -25,7 +25,16 @@ from talentmap_api.fsbid.services import projected_vacancies as pvservices
 logger = logging.getLogger(__name__)
 
 API_ROOT = settings.FSBID_API_URL
+HRDATA_URL = settings.HRDATA_URL
+HRDATA_URL_EXTERNAL = settings.HRDATA_URL_EXTERNAL
 FAVORITES_LIMIT = settings.FAVORITES_LIMIT
+
+def get_employee_profile_urls(clientid):
+    suffix = f"Employees/{clientid}/EmployeeProfileReportByCDO"
+    return {
+        "internal": f"{HRDATA_URL}/{suffix}",
+        "external": f"{HRDATA_URL_EXTERNAL}/{suffix}",
+    }
 
 
 def get_pagination(query, count, base_url, host=None):

--- a/talentmap_api/settings.py
+++ b/talentmap_api/settings.py
@@ -494,7 +494,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'talentmap_api/static/')
 FSBID_API_URL = get_delineated_environment_variable('FSBID_API_URL', 'http://mock_fsbid:3333')
 EMPLOYEES_API_URL = get_delineated_environment_variable('EMPLOYEES_API_URL', 'http://mock_fsbid:3333/Employees')
 HRDATA_URL = get_delineated_environment_variable('HRDATA_URL', 'http://mock_fsbid:3333/HR')
-HRDATA_URL_EXTERNAL = get_delineated_environment_variable('HRDATA_URL', 'http://mock_fsbid:3333/HR')
+HRDATA_URL_EXTERNAL = get_delineated_environment_variable('HRDATA_URL_EXTERNAL', 'http://mock_fsbid:3333/HR')
 AVATAR_URL = get_delineated_environment_variable('AVATAR_URL', 'https://usdos.sharepoint.com/_layouts/15/userphoto.aspx')
 
 SAML_CONFIG_LOADER = 'talentmap_api.settings.config_settings_loader'

--- a/talentmap_api/settings.py
+++ b/talentmap_api/settings.py
@@ -493,8 +493,8 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'talentmap_api/static/')
 
 FSBID_API_URL = get_delineated_environment_variable('FSBID_API_URL', 'http://mock_fsbid:3333')
 EMPLOYEES_API_URL = get_delineated_environment_variable('EMPLOYEES_API_URL', 'http://mock_fsbid:3333/Employees')
-HRDATA_URL = get_delineated_environment_variable('HRDATA_URL', 'http://mock_fsbid:3333/HR')
-HRDATA_URL_EXTERNAL = get_delineated_environment_variable('HRDATA_URL_EXTERNAL', 'http://mock_fsbid:3333/HR')
+HRDATA_URL = get_delineated_environment_variable('HRDATA_URL', 'http://localhost:3333/HR')
+HRDATA_URL_EXTERNAL = get_delineated_environment_variable('HRDATA_URL_EXTERNAL', 'http://localhost:3333/HR')
 AVATAR_URL = get_delineated_environment_variable('AVATAR_URL', 'https://usdos.sharepoint.com/_layouts/15/userphoto.aspx')
 
 SAML_CONFIG_LOADER = 'talentmap_api.settings.config_settings_loader'

--- a/talentmap_api/settings.py
+++ b/talentmap_api/settings.py
@@ -493,6 +493,8 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'talentmap_api/static/')
 
 FSBID_API_URL = get_delineated_environment_variable('FSBID_API_URL', 'http://mock_fsbid:3333')
 EMPLOYEES_API_URL = get_delineated_environment_variable('EMPLOYEES_API_URL', 'http://mock_fsbid:3333/Employees')
+HRDATA_URL = get_delineated_environment_variable('HRDATA_URL', 'http://mock_fsbid:3333/HR')
+HRDATA_URL_EXTERNAL = get_delineated_environment_variable('HRDATA_URL', 'http://mock_fsbid:3333/HR')
 AVATAR_URL = get_delineated_environment_variable('AVATAR_URL', 'https://usdos.sharepoint.com/_layouts/15/userphoto.aspx')
 
 SAML_CONFIG_LOADER = 'talentmap_api.settings.config_settings_loader'


### PR DESCRIPTION
Adds external URLs to the employee profile URLs (one internal network, one external network), as we do not want to proxy the PDF response through the TalentMAP API. Front-end to come.