### PR TITLE
Add bureau_codes mapping for bureau user permissions

### DIFF
--- a/talentmap_api/fsbid/services/employee.py
+++ b/talentmap_api/fsbid/services/employee.py
@@ -57,3 +57,18 @@ ROLE_MAPPING = {
     "CDO3": "cdo",
     "Bureau": "bureau_user",
 }
+
+def get_bureau_permissions(jwt_token, host=None):
+    '''
+    Gets a list of bureau codes assigned to the bureau_user
+    '''
+    url = f"{FSBID_ROOT}/bureauPermissions"
+    response = requests.get(url, headers={'JWTAuthorization': jwt_token, 'Content-Type': 'application/json'}, verify=False).json()  # nosec
+    return map(map_bureau_permissions, response.get("Data", {}))
+
+def map_bureau_permissions(data):
+    return {
+        "code": data.get('bur', None),
+        "long_description": data.get('bureau_long_desc', None),
+        "short_description": data.get('bureau_short_desc', None),
+    }

--- a/talentmap_api/fsbid/urls/employee.py
+++ b/talentmap_api/fsbid/urls/employee.py
@@ -7,5 +7,6 @@ router = routers.SimpleRouter()
 
 urlpatterns = [
     url(r'^perdet_seq_num/$', views.FSBidEmployeePerdetSeqNumActionView.as_view(), name='employee.FSBid-perdet_seq_num-actions'),
+    url(r'^bureau_permissions/$', views.FSBidBureauUserPermissionsView.as_view(), name='employee.FSBid-bureau-permission'),
 ]
 urlpatterns += router.urls

--- a/talentmap_api/fsbid/views/employee.py
+++ b/talentmap_api/fsbid/views/employee.py
@@ -1,6 +1,7 @@
 import logging
 
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
+from talentmap_api.common.permissions import isDjangoGroupMemberOrReadOnly
 from rest_framework.response import Response
 from rest_framework import status
 
@@ -45,3 +46,14 @@ class FSBidEmployeePerdetSeqNumActionView(BaseView):
         auth_user.save()
 
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+class FSBidBureauUserPermissionsView(BaseView):
+    permission_classes = (IsAuthenticatedOrReadOnly, isDjangoGroupMemberOrReadOnly('bureau_user'))
+    '''
+    Get an employee's assigned bureau
+    '''
+    def get(self, request):
+        result = services.get_bureau_permissions(request.META['HTTP_JWT'], f"{request.scheme}://{request.get_host()}")
+        if result is None:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+        return Response(result)


### PR DESCRIPTION
- This creates the service and url for retrieving the authorized bureau codes for a bureau user
- Payload is simply an array of codes(ids) and names(descriptions) for the bureaus to properly display the options available to filter in bureau position management on the FE. 