### PR TITLE
Add new sorts and mappings for bidders TM-1899

### DIFF
--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -164,6 +164,10 @@ sort_dict = {
     "bidder_grade": "grade_code",
     "bidder_skill": "skill_desc",
     "bidder_hs": "handshake_code",
+    # Check fsbid to confirm these mappings work
+    "bidder_language": "language_txt",
+    "bidder_ted": "TED",
+    "bidder_name": "full_name",
 }
 
 


### PR DESCRIPTION
Need to check fsbid to confirm the syntax of these new sorts. Its difficult to check b/c I need to add bids to a cp_id in swagger to check the returned bidders sorting correctly. I will confirm in the comments when ready to merge. Wait till @mjoyce91 merges bureau positions endpoint changes to test locally

Dual Merge: https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/1123