### PR TITLE
Use 3.6.8 for building dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 default-python-node: &default-python-node
-  image: circleci/python:3.7.5
+  image: circleci/python:3.6.8
   environment:
     CC_TEST_REPORTER_ID: b267008efa014a2c3a1ed266efebeb68bad762a948a54a443b4de581a92c45b0
     COMPOSE_FILE_NAME: circleci-docker-compose.yml


### PR DESCRIPTION
Might fix a possible conflict between python versions on CircleCI for building dependencies vs the deployed environment. 