### PR TITLE
adding gal email to user_info

### DIFF
--- a/talentmap_api/fsbid/services/client.py
+++ b/talentmap_api/fsbid/services/client.py
@@ -35,7 +35,7 @@ def get_user_information(jwt_token, perdet_seq_num):
         return {
             "office_address": user['gal_address_text'],
             "office_phone": user['gal_phone_nbr_text'],
-            "email": user['gal_smtp_email_adrs_text'],
+            "email": user['gal_smtp_email_address_text'],
         }
     except:
         return {}

--- a/talentmap_api/fsbid/services/client.py
+++ b/talentmap_api/fsbid/services/client.py
@@ -35,6 +35,7 @@ def get_user_information(jwt_token, perdet_seq_num):
         return {
             "office_address": user['gal_address_text'],
             "office_phone": user['gal_phone_nbr_text'],
+            "email": user['gal_smtp_email_adrs_text'],
         }
     except:
         return {}


### PR DESCRIPTION
adding gal email to user_info; leaving other email alone in case we use it in other places

Dual Merge: [FE](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/1376)