### PR TITLE
Upgrade pysaml2 from 4.4.0 to 4.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ PyJWT==1.7.1
 pylint==2.5.3
 pylint-exit==1.1.0
 pyOpenSSL==17.5.0
-pysaml2==4.4.0
+pysaml2==4.6.0
 pytest==3.5.0
 pytest-cov==2.5.1
 pytest-django==3.1.2

--- a/talentmap_api/settings.py
+++ b/talentmap_api/settings.py
@@ -259,6 +259,7 @@ if ENABLE_SAML2:
                     'name': 'TalentMAP',
                     'allow_unsolicited': True,
                     'name_id_format': saml2.saml.NAMEID_FORMAT_PERSISTENT,
+                    'want_response_signed': False,
                     'endpoints': {
                         # url and binding to the assetion consumer service view
                         # do not change the binding or service name


### PR DESCRIPTION
In response to https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/513
Use minimal safe version to avoid breaking changes