### PR TITLE
Add fake smtp server for local testing

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -24,15 +24,11 @@ docker-compose run mock_fsbid npm run seed
 ```
 
 ## Email Notifications
-For local development, create an account with SparkPost to configure SMTP. Copy your account details into a .env file at the root of this project, formatted as such:
+For local development, a fake SMTP server is included. The dashboard can be accessed on http://localhost:1080. Additional settings can be configured
+in a .env file as such:
 ```
-EMAIL_HOST=smtp.sparkpostmail.com
-EMAIL_PORT=587
-EMAIL_HOST_USER=SMTP_Injection
-EMAIL_HOST_PASSWORD=xxxxxxxxxxxxxxxxxxxxxxxxxxxx
-EMAIL_FROM_ADDRESS=xxxxxxxx@xxxxxxx.com
-EMAIL_USE_TLS=true
-EMAIL_IS_DEV=true # Use for local development
-EMAIL_DEV_TO=xxxxxxxx@xxxxxx.com # Use your own email address. All email notifications will get sent to this address instead of the ones defined in the user's profile
+EMAIL_HOST_PASSWORD=xxxxxxxxxxxxxxxxxxxxxxxxxxxx # If you want to configure the SMTP server with a password
+EMAIL_FROM_ADDRESS=xxxxxxxx@xxxxxxx.com # If you want emails 'from' address to be overridden
+EMAIL_DEV_TO=xxxxxxxx@xxxxxx.com # If you want emails 'to' address to be overridden
 ```
-Do not commit this file to Github. .gitignore is already configured to ignore this file.
+This file is gitignored.

--- a/SETUP.md
+++ b/SETUP.md
@@ -27,8 +27,8 @@ docker-compose run mock_fsbid npm run seed
 For local development, a fake SMTP server is included. The dashboard can be accessed on http://localhost:1080. Additional settings can be configured
 in a .env file as such:
 ```
+EMAIL_HOST_USER=xxxxxxxxxxxx # If you want to configure the SMTP server with a username
 EMAIL_HOST_PASSWORD=xxxxxxxxxxxxxxxxxxxxxxxxxxxx # If you want to configure the SMTP server with a password
-EMAIL_FROM_ADDRESS=xxxxxxxx@xxxxxxx.com # If you want emails 'from' address to be overridden
 EMAIL_DEV_TO=xxxxxxxx@xxxxxx.com # If you want emails 'to' address to be overridden
 ```
 This file is gitignored.

--- a/docker-compose-api-only.yml
+++ b/docker-compose-api-only.yml
@@ -33,14 +33,14 @@ services:
       - ORG_API_URL=http://host.docker.internal:3333/Organizations
       - CLIENTS_API_URL=http://host.docker.internal:3333/Clients
       - TP_API_URL=http://host.docker.internal:3333/TrackingPrograms
-      - EMAIL_ENABLED=${EMAIL_ENABLED}
-      - EMAIL_HOST=${EMAIL_HOST}
-      - EMAIL_PORT=${EMAIL_PORT}
+      - EMAIL_ENABLED=true
+      - EMAIL_HOST=host.docker.internal
+      - EMAIL_PORT=1025
       - EMAIL_HOST_USER=${EMAIL_HOST_USER}
       - EMAIL_HOST_PASSWORD=${EMAIL_HOST_PASSWORD}
-      - EMAIL_FROM_ADDRESS=${EMAIL_FROM_ADDRESS}
-      - EMAIL_USE_TLS=${EMAIL_USE_TLS}
-      - EMAIL_IS_DEV=${EMAIL_IS_DEV}
+      - EMAIL_FROM_ADDRESS=talentmap-alert@local.dev
+      - EMAIL_USE_TLS=false
+      - EMAIL_IS_DEV=false
       - EMAIL_DEV_TO=${EMAIL_DEV_TO}
   oracle:
     ports:
@@ -48,6 +48,11 @@ services:
     image: mjoyce91/oracle193db:fast
     volumes:
       - oracle:/var/lib/oracle/data/:delegated
+  maildev:
+    image: maildev/maildev
+    ports:
+      - "1080:80"
+      - "1025:25"
 volumes:
   pgdata:
   oracle:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - DATABASE_PW=talentmap1
       - DJANGO_DEBUG=true
       - EMAIL_ENABLED=true
-      - EMAIL_HOST=maildev
+      - EMAIL_HOST=host.docker.internal
       - EMAIL_PORT=1025
       - EMAIL_HOST_USER=${EMAIL_HOST_USER}
       - EMAIL_HOST_PASSWORD=${EMAIL_HOST_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,14 +28,14 @@ services:
       - DATABASE_USER=talentmap1
       - DATABASE_PW=talentmap1
       - DJANGO_DEBUG=true
-      - EMAIL_ENABLED=${EMAIL_ENABLED}
-      - EMAIL_HOST=${EMAIL_HOST}
-      - EMAIL_PORT=${EMAIL_PORT}
+      - EMAIL_ENABLED=true
+      - EMAIL_HOST=maildev
+      - EMAIL_PORT=1025
       - EMAIL_HOST_USER=${EMAIL_HOST_USER}
       - EMAIL_HOST_PASSWORD=${EMAIL_HOST_PASSWORD}
-      - EMAIL_FROM_ADDRESS=${EMAIL_FROM_ADDRESS}
-      - EMAIL_USE_TLS=${EMAIL_USE_TLS}
-      - EMAIL_IS_DEV=${EMAIL_IS_DEV}
+      - EMAIL_FROM_ADDRESS=talentmap-alert@local.dev
+      - EMAIL_USE_TLS=false
+      - EMAIL_IS_DEV=false
       - EMAIL_DEV_TO=${EMAIL_DEV_TO}
   oracle:
     ports:
@@ -51,6 +51,11 @@ services:
       - POSTGRES_DB=mockfsbid
       - POSTGRES_USER=mockfsbid-user
       - POSTGRES_PASSWORD=fsbid_pwd
+  maildev:
+    image: maildev/maildev
+    ports:
+      - "1080:80"
+      - "1025:25"
 volumes:
   oracle:
   mock-pgdata:


### PR DESCRIPTION
To test:
- do something that will trigger an email notification (registering a handshake is the easiest)
- navigate to http://localhost:1080 and ensure the email notification appears

Note: emails will not persist between container ups/downs

![Screen Shot 2021-04-29 at 4 05 20 PM](https://user-images.githubusercontent.com/11576347/116611757-bbc2c800-a904-11eb-9fc8-c4464f28aded.png)
