### PR TITLE
Email CDO when bidder accepts/declines a handshake

### DIFF
--- a/talentmap_api/bidding/views/bidhandshake.py
+++ b/talentmap_api/bidding/views/bidhandshake.py
@@ -139,12 +139,13 @@ class BidHandshakeBidderActionView(FieldLimitableSerializerMixin,
         '''
         user = UserProfile.objects.get(user=self.request.user)
         hs = BidHandshake.objects.filter(bidder_perdet=user.emp_id, cp_id=cp_id)
+        jwt = self.request.META['HTTP_JWT']
 
         if not BidHandshake.objects.filter(bidder_perdet=user.emp_id, cp_id=cp_id, status__in=['O', 'A', 'D']).exists():
             return Response(status=status.HTTP_404_NOT_FOUND)
         else:
             hs.update(last_editing_bidder=user, status='A', is_cdo_update=False, update_date=datetime.now())
-            bidderHandshakeNotification(hs.first().owner, cp_id, True)
+            bidderHandshakeNotification(hs.first().owner, cp_id, user.emp_id, jwt, True)
             return Response(status=status.HTTP_204_NO_CONTENT)
 
     def delete(self, request, cp_id, format=None):
@@ -153,10 +154,11 @@ class BidHandshakeBidderActionView(FieldLimitableSerializerMixin,
         '''
         user = UserProfile.objects.get(user=self.request.user)
         hs = BidHandshake.objects.filter(bidder_perdet=user.emp_id, cp_id=cp_id)
+        jwt = self.request.META['HTTP_JWT']
 
         if not BidHandshake.objects.filter(bidder_perdet=user.emp_id, cp_id=cp_id, status__in=['O', 'A', 'D']).exists():
             return Response(status=status.HTTP_404_NOT_FOUND)
         else:
             hs.update(last_editing_bidder=user, status='D', is_cdo_update=False, update_date=datetime.now())
-            bidderHandshakeNotification(hs.first().owner, cp_id, False)
+            bidderHandshakeNotification(hs.first().owner, cp_id, user.emp_id, jwt, False)
             return Response(status=status.HTTP_204_NO_CONTENT)

--- a/talentmap_api/common/common_helpers.py
+++ b/talentmap_api/common/common_helpers.py
@@ -475,9 +475,19 @@ def formatCSV(data, fieldsInfo):
     return fields_formatted
 
 
-def bidderHandshakeNotification(bureau_user, cp_id, is_accept=True):
+def bidderHandshakeNotification(bureau_user, cp_id, perdet, jwt, is_accept=True):
+    from talentmap_api.fsbid.services.cdo import single_cdo
+
     action = "accepted" if is_accept else "declined"
     message = f"Bidder has {action} handshake for position with ID {cp_id}"
+    if perdet and jwt:
+        try:
+            cdo = single_cdo(jwt, perdet)
+            email = pydash.get(cdo, 'email')
+            if email:
+                send_email(message, message, [email])
+        except:#nosec
+            pass
     if bureau_user:
         sendBidHandshakeNotification(bureau_user, message, ['bureau_bidding'], {'id': cp_id})
 


### PR DESCRIPTION
When a bidder accepts or declines a handshake, an email notification is sent to their CDO. This requires a network request to determine who their CDO is and what their email is.