### PR TITLE
Return active and active_handshake_perdet status to bureau position

### DIFF
--- a/talentmap_api/bidding/services/bidhandshake.py
+++ b/talentmap_api/bidding/services/bidhandshake.py
@@ -1,0 +1,27 @@
+import logging
+import pydash
+
+from talentmap_api.bidding.models import BidHandshake
+
+logger = logging.getLogger(__name__)
+
+
+def get_position_handshake_data(cp_id):
+    '''
+    Return whether the cycle position is active and to which perdet, if any, possesses the active handshake
+    '''
+    props = {
+        'active': False,
+        'active_handshake_perdet': None,
+    }
+
+    hs = BidHandshake.objects.filter(cp_id=cp_id).values()
+    active = pydash.filter_(hs, lambda x: x['status'] is not 'R')
+    if len(active) is 0:
+        props['active'] = True
+    
+    active = pydash.find(hs, lambda x: x['status'] is 'O' or x['status'] is 'A')
+    if active:
+        props['active_handshake_perdet'] = active['bidder_perdet']
+
+    return props

--- a/talentmap_api/fsbid/services/bureau.py
+++ b/talentmap_api/fsbid/services/bureau.py
@@ -11,6 +11,7 @@ from talentmap_api.common.common_helpers import ensure_date, validate_values
 
 import talentmap_api.fsbid.services.bid as bid_services
 import talentmap_api.fsbid.services.cdo as cdoservices
+import talentmap_api.bidding.services.bidhandshake as bh_services
 import talentmap_api.fsbid.services.common as services
 
 from talentmap_api.available_positions.models import AvailablePositionRanking
@@ -141,6 +142,9 @@ def fsbid_bureau_positions_to_talentmap(bp):
     '''
     Converts the response bureau position from FSBid to a format more in line with the Talentmap position
     '''
+
+    bh_props = bh_services.get_position_handshake_data(bp.get("cp_id", None))
+
     hasHandShakeOffered = False
     if bp.get("cp_status", None) == "HS":
         hasHandShakeOffered = True
@@ -262,6 +266,7 @@ def fsbid_bureau_positions_to_talentmap(bp):
             "has_handshake_offered": hasHandShakeOffered,
             "has_handshake_accepted": None
         }],
+        "bid_handshake": bh_props,
         "unaccompaniedStatus": bp.get("us_desc_text", None),
         "isConsumable": bp.get("bt_consumable_allowance_flg", None) == "Y",
         "isServiceNeedDifferential": bp.get("bt_service_needs_diff_flg", None) == "Y",


### PR DESCRIPTION
Return bid handshake data points to the bureau position:
- `active` - cp_id can only have “R”s or not exist to be considered active
- `active_handshake_perdet` - the perdet of any `O` or `A` status bid on the given cycle position