### PR TITLE
Return bureau code when mapped by available bidders function

### DIFF
--- a/talentmap_api/fsbid/services/client.py
+++ b/talentmap_api/fsbid/services/client.py
@@ -475,6 +475,7 @@ def fsbid_assignments_to_tmap(assignments):
                         "skill": f"{pos.get('pos_skill_desc', None)} ({pos.get('pos_skill_code')})",
                         "skill_code": pos.get("pos_skill_code", None),
                         "bureau": f"({pos.get('pos_bureau_short_desc', None)}) {pos.get('pos_bureau_long_desc', None)}",
+                        "bureau_code": pos.get('bureau', None).get('bureau_short_desc', None), # only comes through for available bidders
                         "organization": pos.get('pos_org_short_desc', None),
                         "position_number": pos.get('pos_seq_num', None),
                         "title": pos.get("pos_title_desc", None),


### PR DESCRIPTION
This mapping isn't completely compatible with available bidders data, but this update at least gets the bureau code to return so that we can use it to populate the Edit Bidder modal.