### PR TITLE
Maintain expire on Revoke status update for historical hs

### DIFF
--- a/talentmap_api/bidding/views/bidhandshake.py
+++ b/talentmap_api/bidding/views/bidhandshake.py
@@ -66,7 +66,7 @@ class BidHandshakeBureauActionView(FieldLimitableSerializerMixin,
 
         # Revoke any previously offered handshakes for this cp_id
         hsToArchive = BidHandshake.objects.exclude(bidder_perdet=pk).filter(cp_id=cp_id)
-        hsToArchive.update(last_editing_user=user, status='R', update_date=datetime.now(), date_revoked=datetime.now(), expiration_date=None)
+        hsToArchive.update(last_editing_user=user, status='R', update_date=datetime.now(), date_revoked=datetime.now())
         expiration = pydash.get(request, 'data.expiration_date')
 
         if hs.exists():


### PR DESCRIPTION
Don't reset expiration UNTIL new offer on THIS handshake. The assumption is _EVERY_ valid HS has an expiration until it is overwritten -> we'll use that expiration_date to determine status icons, and info-only modal expiration time (historical). Otherwise we cannot show the expired icon after revoke or the past expiration time before re-offer (on currently revoked). 