### PR TITLE
Add dict for new sorts for tandem TM-2278

### DIFF
--- a/talentmap_api/fsbid/services/available_positions.py
+++ b/talentmap_api/fsbid/services/available_positions.py
@@ -356,7 +356,7 @@ def convert_ap_query(query, allowed_status_codes=["HS", "OP"], isTandem=False):
     if isTandem:
         ordering = query.get("ordering", None)
         values["request_params.count"] = query.get("getCount", 'false')
-        values["request_params.order_by"] = services.sorting_values(f"commuterPost,location,tandem,{ordering}")
+        values["request_params.order_by"] = services.sorting_values(f"commuterPost,location,location_code,tandem,{ordering}")
         # Common filters
         values["request_params.overseas_ind2"] = services.overseas_values(query)
         values["request_params.location_codes2"] = services.post_values(query)

--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -140,6 +140,8 @@ sort_dict = {
     "location_city": "geoloc.city",
     "location_country": "geoloc.country",
     "location_state": "geoloc.state",
+    "location": "location_city",
+    "location_code": "pos_location_code",
     "commuterPost": "cpn_desc",
     "tandem": "tandem_nbr",
     "bidder_grade": "grade_code",


### PR DESCRIPTION
Bug: Tandem hierarchal sort isn't working properly (Tandem 1 and Tandem 2 results should be grouped logically specified below)
- This should properly map the fixed sorts
1. CommuterPosts
2. Location (city)
3. (location code for duplication locations above) 
4. Tandem
5. Specified User Sort (last) 