### PR TITLE
Exclude Revoked HS from bidder bid list

### DIFF
--- a/talentmap_api/bidding/services/bidhandshake.py
+++ b/talentmap_api/bidding/services/bidhandshake.py
@@ -23,7 +23,7 @@ def get_position_handshake_data(cp_id):
     return props
 
 
-def get_bidder_handshake_data(cp_id, perdet):
+def get_bidder_handshake_data(cp_id, perdet, exclude_revoked=False):
     '''
     Return handshake data for a given perdet and cp_id
     '''
@@ -51,6 +51,8 @@ def get_bidder_handshake_data(cp_id, perdet):
     }
 
     hs = BidHandshake.objects.filter(cp_id=cp_id, bidder_perdet=perdet)
+    if exclude_revoked:
+        hs = hs.exclude(status='R')
 
     if hs.exists():
         hs = hs.first()

--- a/talentmap_api/fsbid/services/bid.py
+++ b/talentmap_api/fsbid/services/bid.py
@@ -197,7 +197,7 @@ def fsbid_bid_to_talentmap_bid(data, jwt_token):
 
     if showHandshakeData:
         data["handshake"] = {
-            **bh_services.get_bidder_handshake_data(cpId, perdet),
+            **bh_services.get_bidder_handshake_data(cpId, perdet, True),
         }
 
     return data


### PR DESCRIPTION
Prevents revoked handshakes from appearing on the bidder/CDO bid list. Previously, if a bidder accepted a handshake but then it was revoked, the HS overlay would still appear in the UI. This PR resolves that issue.