### PR TITLE
Update so that bidder can only accept one handshake per bid cycle

### DIFF
--- a/talentmap_api/bidding/views/bidhandshake.py
+++ b/talentmap_api/bidding/views/bidhandshake.py
@@ -145,9 +145,9 @@ class BidHandshakeCdoActionView(FieldLimitableSerializerMixin,
         else:
             # Return an error if a handshake has already been accepted within active
             bids = bid_services.user_bids(pk, jwt)
-            accept_disabled = pydash.find(bids, lambda x: x['accept_handshake_disabled'] == True)
+            accept_disabled = pydash.find(bids, lambda x: str(int(pydash.get(x, 'position_info.id'))) == str(int(cp_id)) and x['accept_handshake_disabled'] is True)
             if accept_disabled:
-                return Response('A handshake has already been accepted', status=status.HTTP_409_CONFLICT)
+                return Response('A handshake in this cycle position bid cycle has already been accepted', status=status.HTTP_409_CONFLICT)
 
             hs.update(last_editing_bidder=user, status='A', bidder_status='A', is_cdo_update=True,
                 update_date=datetime.now(), date_accepted=datetime.now())
@@ -193,9 +193,9 @@ class BidHandshakeBidderActionView(FieldLimitableSerializerMixin,
         else:
             # Return an error if a handshake has already been accepted within active
             bids = bid_services.user_bids(user.emp_id, jwt)
-            accept_disabled = pydash.find(bids, lambda x: x['accept_handshake_disabled'] == True)
+            accept_disabled = pydash.find(bids, lambda x: str(int(pydash.get(x, 'position_info.id'))) == str(int(cp_id)) and x['accept_handshake_disabled'] is True)
             if accept_disabled:
-                return Response('A handshake has already been accepted', status=status.HTTP_409_CONFLICT)
+                return Response('A handshake in this cycle position bid cycle has already been accepted', status=status.HTTP_409_CONFLICT)
 
             hs.update(last_editing_bidder=user, status='A', bidder_status='A', is_cdo_update=False,
                 update_date=datetime.now(), date_accepted=datetime.now())

--- a/talentmap_api/fsbid/services/bid.py
+++ b/talentmap_api/fsbid/services/bid.py
@@ -100,13 +100,23 @@ def remove_bid(employeeId, cyclePositionId, jwt_token):
 
 
 def map_bids_to_disable_handshake_if_accepted(bids):
+    # Accepting a handshake should be disabled if another handshake within the same bid cycle has already been accepted
+
     bidsClone = deepcopy(list(bids))
+
+    # get the cp_id and related bid cycle id of accepted handshakes
     hasAcceptedHandshakeIds = pydash.chain(bidsClone).filter_(
         lambda x: pydash.get(x, 'handshake.bidder_hs_code') == 'handshake_accepted' and pydash.get(x, 'handshake.hs_status_code') != 'handshake_revoked'
-    ).map('id').value()
+    ).map(
+        lambda x: { 'cp_id': pydash.get(x, 'position_info.id'), 'cycle_id': pydash.get(x, 'position_info.bidcycle.id') }
+    ).value()
+
     bidsClone = pydash.map_(bidsClone, lambda x: {
             **x,
-            'accept_handshake_disabled': False if not hasAcceptedHandshakeIds else True if x['id'] not in hasAcceptedHandshakeIds else False
+            'accept_handshake_disabled': True if pydash.find(hasAcceptedHandshakeIds, lambda y:
+                y['cycle_id'] == pydash.get(x, 'position_info.bidcycle.id'))
+                and not pydash.find(hasAcceptedHandshakeIds, lambda y: y['cp_id'] == pydash.get(x, 'position_info.id'))
+                else False,
         })
     return bidsClone
 


### PR DESCRIPTION
Previously: bidder could only accept a handshake if they did not have any other accepted handshakes within any active bid cycle
With this PR: bidder can only accept one handshake within a bid cycle, regardless of whether they've accepted a handshake in another active cycle