### PR TITLE
null-check-for-mapping TM-2283

### DIFF
--- a/talentmap_api/fsbid/services/client.py
+++ b/talentmap_api/fsbid/services/client.py
@@ -543,7 +543,7 @@ def fsbid_languages_to_tmap(languages):
             "test_date": ensure_date(x.get('empl_high_test_date', None)),
             "speaking_score": x.get('empl_high_speaking', None),
             "reading_score": x.get('empl_high_reading', None),
-            "custom_description": f"{x.get('empl_language')} {x.get('empl_high_speaking')}/{x.get('empl_high_reading')}"
+            "custom_description": f"{x.get('empl_language')} {x.get('empl_high_speaking', '--')}/{x.get('empl_high_reading', '--')}"
         })
     return tmap_languages
 

--- a/talentmap_api/fsbid/services/client.py
+++ b/talentmap_api/fsbid/services/client.py
@@ -505,6 +505,8 @@ def fsbid_assignments_to_tmap(assignments):
 def fsbid_languages_to_tmap(languages):
     tmap_languages = []
     for x in languages:
+        if not x.get('empl_language', None):
+            continue
         tmap_languages.append({
             "code": x.get('empl_language_code', None),
             "language": x.get('empl_language', None),


### PR DESCRIPTION
- ~~Still trying to correctly mock out the scenario, but~~ this should prevent tmap from mapping the language object if there's not title for the language
- Modified custom description in lang object to be used on modal to account for missing test scores