### PR TITLE
Handle non-existent skill lookup

### DIFF
--- a/talentmap_api/fsbid/services/client.py
+++ b/talentmap_api/fsbid/services/client.py
@@ -394,19 +394,25 @@ def map_skill_codes(data):
         if i == 1:
             index = ''
         code = pydash.get(data, f'per_skill{index}_code', None)
-        desc = pydash.get(data, f'per_skill{index}_code_desc', None)
+        desc = pydash.get(data, f'per_skill{index}_code_desc', None) # Not coming through with /Persons
         skills.append({'code': code, 'description': desc})
     return filter(lambda x: x.get('code', None) is not None, skills)
 
 
 def map_skill_codes_additional(skills, employeeSkills):
     employeeCodesAdd = []
-    for w in employeeSkills:
-        foundSkill = [a for a in skills if a['skl_code'] == w['code']][0]
-        cone = foundSkill['jc_nm_txt']
-        foundSkillsByCone = [b for b in skills if b['jc_nm_txt'] == cone]
-        for x in foundSkillsByCone:
-            employeeCodesAdd.append(x['skl_code'])
+    try:
+        for w in employeeSkills:
+            foundSkill = [a for a in skills if a['skl_code'] == w['code']]
+            # some times, the user's skill is not in the full /skillCodes list
+            if foundSkill:
+                foundSkill = foundSkill[0]
+                cone = foundSkill['jc_nm_txt']
+                foundSkillsByCone = [b for b in skills if b['jc_nm_txt'] == cone]
+                for x in foundSkillsByCone:
+                    employeeCodesAdd.append(x['skl_code'])
+    except Exception as e:
+        logger.error(f"{type(e).__name__} at line {e.__traceback__.tb_lineno} of {__file__}: {e}")
     return set(employeeCodesAdd)
 
 

--- a/talentmap_api/fsbid/services/employee.py
+++ b/talentmap_api/fsbid/services/employee.py
@@ -43,7 +43,8 @@ def get_employee_information(jwt_token, emp_id):
             "grade": pydash.get(employee, 'per_grade_code', '').replace(" ", ""),
             "skills_additional": map_skill_codes_additional(skills, employeeSkills),
         }
-    except:
+    except Exception as e:
+        logger.error(f"{type(e).__name__} at line {e.__traceback__.tb_lineno} of {__file__}: {e}")
         return {}
 
 


### PR DESCRIPTION
Fixes an issue where if one of a user's skill codes can't be matched against the /skillCodes list, their entire `employee_info` doesn't load.

To re-create:
- Use dev branch API
- In the mock, go to the `get_persons` function (/services/employees.js)
- Below `...personSkills(emp.skills)`, add `per_skill_2_code: '6AAA',` and save
- Go your TalentMAP private profile. Grade and skill should not appear, since this is a non-existent skill code, causing the mapping on our API to fail
- Use this branch and refresh to see the fix