### PR TITLE
Force return of ID in position_info

### DIFF
--- a/talentmap_api/fsbid/services/bid.py
+++ b/talentmap_api/fsbid/services/bid.py
@@ -184,7 +184,7 @@ def fsbid_bid_to_talentmap_bid(data, jwt_token):
     canDelete = True if data.get('delete_ind', 'Y') == 'Y' else False
     cpId = int(data.get('cp_id'))
     perdet = str(int(float(data.get('perdet_seq_num'))))
-    positionInfo = ap_services.get_available_position(str(cpId), jwt_token)
+    positionInfo = ap_services.get_available_position(str(cpId), jwt_token) or {}
     cycle = pydash.get(positionInfo, 'bidcycle.id')
 
     showHandshakeData = True
@@ -217,7 +217,10 @@ def fsbid_bid_to_talentmap_bid(data, jwt_token):
         "update_date": "",
         "reviewer": "",
         "cdo_bid": data.get('cdo_bid') == 'Y',
-        "position_info": positionInfo,
+        "position_info": {
+            "id": str(cpId), # even if we can't return positionInfo, we can at least return id
+            **positionInfo,
+        },
     }
 
     if showHandshakeData:

--- a/talentmap_api/fsbid/services/bid.py
+++ b/talentmap_api/fsbid/services/bid.py
@@ -218,7 +218,7 @@ def fsbid_bid_to_talentmap_bid(data, jwt_token):
         "reviewer": "",
         "cdo_bid": data.get('cdo_bid') == 'Y',
         "position_info": {
-            "id": str(cpId), # even if we can't return positionInfo, we can at least return id
+            "id": cpId, # even if we can't return positionInfo, we can at least return id
             **positionInfo,
         },
     }


### PR DESCRIPTION
This is needed when we need to do cp_id checks inside position_info, but position_info isn't returned because the bid isn't returned by ap_services. https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/598 should make that irrelevant (?) but still wanted to fix this.