### PR TITLE
refactoring get_individual (includes AI Export fix)

### DIFF
--- a/talentmap_api/available_positions/urls/available_positions.py
+++ b/talentmap_api/available_positions/urls/available_positions.py
@@ -9,9 +9,7 @@ router = routers.SimpleRouter()
 
 urlpatterns = [
     url(r'^favorites/export/$', views.FavoritesCSVView.as_view(), name='export-all-favorites'),
-    # 🚨 I don't think we use the one below anywhere - will confirm
     url(r'^favorites/$', views.AvailablePositionFavoriteListView.as_view(), name='view-favorite-available-positions'),
-    # 🚨 ^^
     url(r'^favorites/ids/$', views.AvailablePositionFavoriteIdsListView.as_view(), name='view-favorite-available-positions-ids'),
     url(r'^(?P<pk>[0-9]+)/favorite/$', views.AvailablePositionFavoriteActionView.as_view(), name='available_positions-AvailablePositionFavorite-favorite'),
     url(r'^(?P<pk>[0-9]+)/designation/$', views.AvailablePositionDesignationView.as_view({**patch_update}), name='available_positions-AvailablePositionDesignation-designation'),

--- a/talentmap_api/available_positions/urls/available_positions.py
+++ b/talentmap_api/available_positions/urls/available_positions.py
@@ -9,7 +9,9 @@ router = routers.SimpleRouter()
 
 urlpatterns = [
     url(r'^favorites/export/$', views.FavoritesCSVView.as_view(), name='export-all-favorites'),
+    # 🚨 I don't think we use the one below anywhere - will confirm
     url(r'^favorites/$', views.AvailablePositionFavoriteListView.as_view(), name='view-favorite-available-positions'),
+    # 🚨 ^^
     url(r'^favorites/ids/$', views.AvailablePositionFavoriteIdsListView.as_view(), name='view-favorite-available-positions-ids'),
     url(r'^(?P<pk>[0-9]+)/favorite/$', views.AvailablePositionFavoriteActionView.as_view(), name='available_positions-AvailablePositionFavorite-favorite'),
     url(r'^(?P<pk>[0-9]+)/designation/$', views.AvailablePositionDesignationView.as_view({**patch_update}), name='available_positions-AvailablePositionDesignation-designation'),

--- a/talentmap_api/fsbid/services/agenda.py
+++ b/talentmap_api/fsbid/services/agenda.py
@@ -66,7 +66,7 @@ def get_agenda_item_history_csv(query, jwt_token, host, limit=None):
         "query": query,
         "query_mapping_function": convert_agenda_item_query,
         "jwt_token": jwt_token,
-        "mapping_function": partial(fsbid_agenda_items_to_talentmap_agenda_items, jwt_token=jwt_token),
+        "mapping_function": fsbid_single_agenda_item_to_talentmap_single_agenda_item,
         "host": host,
         "use_post": False,
         "base_url": AGENDA_API_ROOT,

--- a/talentmap_api/fsbid/services/agenda.py
+++ b/talentmap_api/fsbid/services/agenda.py
@@ -1,5 +1,4 @@
 import logging
-import jwt
 import pydash
 from functools import partial
 from urllib.parse import urlencode, quote
@@ -15,19 +14,18 @@ AGENDA_API_ROOT = settings.AGENDA_API_URL
 logger = logging.getLogger(__name__)
 
 
-def get_single_agenda_item(jwt_token=None, ai_id = None):
+def get_single_agenda_item(jwt_token=None, pk=None):
     '''
     Get single agenda item
     '''
     args = {
         "uri": "",
-        "id": ai_id,
+        "query": {'aiseqnum': pk},
         "query_mapping_function": convert_agenda_item_query,
         "jwt_token": jwt_token,
         "mapping_function": fsbid_single_agenda_item_to_talentmap_single_agenda_item,
         "use_post": False,
         "api_root": AGENDA_API_ROOT,
-        "use_id": False,
     }
 
     agenda_item = services.get_individual(
@@ -110,7 +108,10 @@ def convert_agenda_item_query(query):
         "rp.pageRows": int(query.get("limit", 1000)),
         "rp.columns": None,
         "rp.orderBy": services.sorting_values(query.get("ordering", "agenda_id")),
-        "rp.filter": services.convert_to_fsbid_ql([{'col': 'aiperdetseqnum', 'val': query.get("perdet", None)}]),
+        "rp.filter": services.convert_to_fsbid_ql([
+            {'col': 'aiperdetseqnum', 'val': query.get("perdet", None)},
+            {'col': 'aiseqnum', 'val': query.get("aiseqnum", None)}
+        ]),
     }
 
     valuesToReturn = pydash.omit_by(values, lambda o: o is None or o == [])

--- a/talentmap_api/fsbid/services/agenda.py
+++ b/talentmap_api/fsbid/services/agenda.py
@@ -24,15 +24,16 @@ def get_single_agenda_item(jwt_token=None, pk=None):
         "query_mapping_function": convert_agenda_item_query,
         "jwt_token": jwt_token,
         "mapping_function": fsbid_single_agenda_item_to_talentmap_single_agenda_item,
-        "use_post": False,
+        "count_function": None,
+        "base_url": "/api/v1/fsbid/agenda/",
         "api_root": AGENDA_API_ROOT,
     }
 
-    agenda_item = services.get_individual(
+    agenda_item = services.send_get_request(
         **args
     )
 
-    return agenda_item
+    return pydash.get(agenda_item, 'results[0]') or None
 
 
 def get_agenda_items(jwt_token=None, query = {}, host=None):

--- a/talentmap_api/fsbid/services/available_positions.py
+++ b/talentmap_api/fsbid/services/available_positions.py
@@ -43,7 +43,7 @@ def get_unavailable_position(id, jwt_token):
     '''
     return services.get_individual(
         "availablePositions",
-        id,
+        {"id": id},
         convert_up_query,
         jwt_token,
         fsbid_ap_to_talentmap_ap

--- a/talentmap_api/fsbid/services/available_positions.py
+++ b/talentmap_api/fsbid/services/available_positions.py
@@ -24,13 +24,12 @@ def get_available_position(id, jwt_token):
 
     args = {
         "uri": "available",
-        "id": id,
+        "query": {"id": id},
         "query_mapping_function": convert_all_query,
         "jwt_token": jwt_token,
         "mapping_function": fsbid_ap_to_talentmap_ap,
         "use_post": True,
         "api_root": CP_API_V2_URL,
-        "use_id": False,
     }
 
     return services.get_individual(

--- a/talentmap_api/fsbid/services/available_positions.py
+++ b/talentmap_api/fsbid/services/available_positions.py
@@ -30,11 +30,15 @@ def get_available_position(id, jwt_token):
         "mapping_function": fsbid_ap_to_talentmap_ap,
         "use_post": True,
         "api_root": CP_API_V2_URL,
+        "count_function": None,
+        "base_url": "/api/v1/fsbid/available_positions/",
     }
 
-    return services.get_individual(
+    ap_position = services.send_get_request(
         **args
     )
+
+    return pydash.get(ap_position, 'results[0]') or None
 
 
 def get_unavailable_position(id, jwt_token):

--- a/talentmap_api/fsbid/services/available_positions.py
+++ b/talentmap_api/fsbid/services/available_positions.py
@@ -21,7 +21,6 @@ def get_available_position(id, jwt_token):
     '''
     Gets an indivdual available position by id
     '''
-
     args = {
         "uri": "available",
         "id": id,
@@ -30,8 +29,8 @@ def get_available_position(id, jwt_token):
         "mapping_function": fsbid_ap_to_talentmap_ap,
         "use_post": True,
         "api_root": CP_API_V2_URL,
+        "use_id": False,
     }
-
     return services.get_individual(
         **args
     )
@@ -365,7 +364,9 @@ def convert_ap_query(query, allowed_status_codes=["HS", "OP"], isTandem=False):
     '''
 
     prefix = ""
-
+    print('🐸🐸🐸🐸🐸🐸🐸🐸🐸🐸')
+    print(query)
+    print('🐸🐸🐸🐸🐸🐸🐸🐸🐸🐸')
     values = {
         # Pagination
         f"{prefix}order_by": services.sorting_values(query.get("ordering", None), True),
@@ -446,6 +447,9 @@ def convert_all_query(query):
     to convert_ap_query request_params.cps_codes of anything
     but FP, OP, or HS will get removed from query
     '''
+    print('👾👾👾👾👾👾👾👾👾👾👾')
+    print(query)
+    print('👾👾👾👾👾👾👾👾👾👾👾')
     return convert_ap_query(query, ["FP", "OP", "HS"], False)
 
 

--- a/talentmap_api/fsbid/services/available_positions.py
+++ b/talentmap_api/fsbid/services/available_positions.py
@@ -45,13 +45,17 @@ def get_unavailable_position(id, jwt_token):
     '''
     Gets an indivdual unavailable position by id
     '''
-    return services.get_individual(
+    ua_pos = services.send_get_request(
         "availablePositions",
         {"id": id},
         convert_up_query,
         jwt_token,
-        fsbid_ap_to_talentmap_ap
+        fsbid_ap_to_talentmap_ap,
+        None,
+        "/api/v1/fsbid/available_positions/"
     )
+
+    return pydash.get(ua_pos, 'results[0]') or None
 
 
 def get_all_position(id, jwt_token):

--- a/talentmap_api/fsbid/services/available_positions.py
+++ b/talentmap_api/fsbid/services/available_positions.py
@@ -58,7 +58,7 @@ def get_all_position(id, jwt_token):
 
     args = {
         "uri": "",
-        "id": id,
+        "query": {"id": id},
         "query_mapping_function": convert_all_query,
         "jwt_token": jwt_token,
         "mapping_function": fsbid_ap_to_talentmap_ap,

--- a/talentmap_api/fsbid/services/available_positions.py
+++ b/talentmap_api/fsbid/services/available_positions.py
@@ -364,9 +364,6 @@ def convert_ap_query(query, allowed_status_codes=["HS", "OP"], isTandem=False):
     '''
 
     prefix = ""
-    print('🐸🐸🐸🐸🐸🐸🐸🐸🐸🐸')
-    print(query)
-    print('🐸🐸🐸🐸🐸🐸🐸🐸🐸🐸')
     values = {
         # Pagination
         f"{prefix}order_by": services.sorting_values(query.get("ordering", None), True),
@@ -447,9 +444,6 @@ def convert_all_query(query):
     to convert_ap_query request_params.cps_codes of anything
     but FP, OP, or HS will get removed from query
     '''
-    print('👾👾👾👾👾👾👾👾👾👾👾')
-    print(query)
-    print('👾👾👾👾👾👾👾👾👾👾👾')
     return convert_ap_query(query, ["FP", "OP", "HS"], False)
 
 

--- a/talentmap_api/fsbid/services/available_positions.py
+++ b/talentmap_api/fsbid/services/available_positions.py
@@ -21,6 +21,7 @@ def get_available_position(id, jwt_token):
     '''
     Gets an indivdual available position by id
     '''
+
     args = {
         "uri": "available",
         "id": id,
@@ -31,6 +32,7 @@ def get_available_position(id, jwt_token):
         "api_root": CP_API_V2_URL,
         "use_id": False,
     }
+
     return services.get_individual(
         **args
     )
@@ -364,6 +366,7 @@ def convert_ap_query(query, allowed_status_codes=["HS", "OP"], isTandem=False):
     '''
 
     prefix = ""
+
     values = {
         # Pagination
         f"{prefix}order_by": services.sorting_values(query.get("ordering", None), True),

--- a/talentmap_api/fsbid/services/available_positions.py
+++ b/talentmap_api/fsbid/services/available_positions.py
@@ -63,11 +63,15 @@ def get_all_position(id, jwt_token):
         "mapping_function": fsbid_ap_to_talentmap_ap,
         "use_post": True,
         "api_root": CP_API_V2_URL,
+        "count_function": None,
+        "base_url": "/api/v1/fsbid/cdo/",
     }
 
-    return services.get_individual(
+    position = services.send_get_request(
         **args
     )
+
+    return pydash.get(position, 'results[0]') or None
 
 
 def get_available_positions(query, jwt_token, host=None):

--- a/talentmap_api/fsbid/services/bureau.py
+++ b/talentmap_api/fsbid/services/bureau.py
@@ -36,7 +36,7 @@ def get_bureau_position(id, jwt_token):
 
     return get_individual(
         "",
-        id,
+        {"id": id},
         partial(convert_bp_query, use_post=True),
         jwt_token,
         fsbid_bureau_positions_to_talentmap,

--- a/talentmap_api/fsbid/services/bureau.py
+++ b/talentmap_api/fsbid/services/bureau.py
@@ -32,17 +32,22 @@ def get_bureau_position(id, jwt_token):
     '''
     Gets an indivdual bureau position by id
     '''
-    from talentmap_api.fsbid.services.common import get_individual
+    from talentmap_api.fsbid.services.common import send_get_request
 
-    return get_individual(
+    bureau_pos = send_get_request(
         "",
         {"id": id},
         partial(convert_bp_query, use_post=True),
         jwt_token,
         fsbid_bureau_positions_to_talentmap,
+        None,
+        "/api/v1/fsbid/bureau/",
+        None,
         CP_API_V2_ROOT,
         True,
     )
+
+    return pydash.get(bureau_pos, 'results[0]') or None
 
 
 def get_bureau_positions(query, jwt_token, host=None):

--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -203,8 +203,6 @@ def get_results(uri, query, query_mapping_function, jwt_token, mapping_function,
         url = f"{api_root}/{uri}?{query_mapping_function(queryClone)}"
     else:
         url = f"{api_root}/{uri}"
-    print('🍁', url)
-    print('🍁🍁', query)
     response = requests.get(url, headers={'JWTAuthorization': jwt_token, 'Content-Type': 'application/json'}).json()
     if response.get("Data") is None or ((response.get('return_code') and response.get('return_code', -1) == -1) or (response.get('ReturnCode') and response.get('ReturnCode', -1) == -1)):
         logger.error(f"Fsbid call to '{url}' failed.")
@@ -218,8 +216,6 @@ def get_results(uri, query, query_mapping_function, jwt_token, mapping_function,
 def get_results_with_post(uri, query, query_mapping_function, jwt_token, mapping_function, api_root=API_ROOT):
     mappedQuery = pydash.omit_by(query_mapping_function(query), lambda o: o == None)
     url = f"{api_root}/{uri}"
-    print('🌲', url)
-    print('🌲🌲', query)
     response = requests.post(url, headers={'JWTAuthorization': jwt_token, 'Content-Type': 'application/json'}, json=mappedQuery).json()
     if response.get("Data") is None or ((response.get('return_code') and response.get('return_code', -1) == -1) or (response.get('ReturnCode') and response.get('ReturnCode', -1) == -1)):
         logger.error(f"Fsbid call to '{url}' failed.")

--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -203,6 +203,8 @@ def get_results(uri, query, query_mapping_function, jwt_token, mapping_function,
         url = f"{api_root}/{uri}?{query_mapping_function(queryClone)}"
     else:
         url = f"{api_root}/{uri}"
+    print('🍁', url)
+    print('🍁🍁', query)
     response = requests.get(url, headers={'JWTAuthorization': jwt_token, 'Content-Type': 'application/json'}).json()
     if response.get("Data") is None or ((response.get('return_code') and response.get('return_code', -1) == -1) or (response.get('ReturnCode') and response.get('ReturnCode', -1) == -1)):
         logger.error(f"Fsbid call to '{url}' failed.")
@@ -216,6 +218,8 @@ def get_results(uri, query, query_mapping_function, jwt_token, mapping_function,
 def get_results_with_post(uri, query, query_mapping_function, jwt_token, mapping_function, api_root=API_ROOT):
     mappedQuery = pydash.omit_by(query_mapping_function(query), lambda o: o == None)
     url = f"{api_root}/{uri}"
+    print('🌲', url)
+    print('🌲🌲', query)
     response = requests.post(url, headers={'JWTAuthorization': jwt_token, 'Content-Type': 'application/json'}, json=mappedQuery).json()
     if response.get("Data") is None or ((response.get('return_code') and response.get('return_code', -1) == -1) or (response.get('ReturnCode') and response.get('ReturnCode', -1) == -1)):
         logger.error(f"Fsbid call to '{url}' failed.")
@@ -251,7 +255,6 @@ def get_individual(uri, query, query_mapping_function, jwt_token, mapping_functi
     '''
     fetch_method = get_results_with_post if use_post else get_results
     response = fetch_method(uri, query, query_mapping_function, jwt_token, mapping_function, api_root)
-    # response = fetch_method(f"{uri}{id}" if use_id else uri, {"id": id}, query_mapping_function, jwt_token, mapping_function, api_root)
     return pydash.get(response, '[0]') or None
 
 

--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -245,12 +245,13 @@ def get_fsbid_results(uri, jwt_token, mapping_function, email=None, use_cache=Fa
     return map(mapping_function, response.get("Data", {}))
 
 
-def get_individual(uri, id, query_mapping_function, jwt_token, mapping_function, api_root=API_ROOT, use_post=False, use_id = True):
+def get_individual(uri, query, query_mapping_function, jwt_token, mapping_function, api_root=API_ROOT, use_post=False):
     '''
     Gets an individual record by the provided ID
     '''
     fetch_method = get_results_with_post if use_post else get_results
-    response = fetch_method(f"{uri}{id}" if use_id else uri, {"id": id}, query_mapping_function, jwt_token, mapping_function, api_root)
+    response = fetch_method(uri, query, query_mapping_function, jwt_token, mapping_function, api_root)
+    # response = fetch_method(f"{uri}{id}" if use_id else uri, {"id": id}, query_mapping_function, jwt_token, mapping_function, api_root)
     return pydash.get(response, '[0]') or None
 
 

--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -250,7 +250,7 @@ def get_individual(uri, id, query_mapping_function, jwt_token, mapping_function,
     Gets an individual record by the provided ID
     '''
     fetch_method = get_results_with_post if use_post else get_results
-    response = fetch_method(uri if use_id else f"{uri}{id}", {"id": id} if use_id else {}, query_mapping_function, jwt_token, mapping_function, api_root)
+    response = fetch_method(f"{uri}{id}" if use_id else uri, {"id": id}, query_mapping_function, jwt_token, mapping_function, api_root)
     return pydash.get(response, '[0]') or None
 
 

--- a/talentmap_api/fsbid/services/positions.py
+++ b/talentmap_api/fsbid/services/positions.py
@@ -11,13 +11,17 @@ def get_position(id, jwt_token):
     '''
     Gets an individual unavailable position by id
     '''
-    return services.get_individual(
+    position = services.send_get_request(
         "Positions",
         {"id": id},
         convert_pos_query,
         jwt_token,
-        fsbid_pos_to_talentmap_pos
+        fsbid_pos_to_talentmap_pos,
+        None,
+        "/api/v1/fsbid/positions/",
     )
+
+    return pydash.get(position, 'results[0]') or None
 
 def fsbid_pos_to_talentmap_pos(pos):
     '''

--- a/talentmap_api/fsbid/services/positions.py
+++ b/talentmap_api/fsbid/services/positions.py
@@ -9,11 +9,11 @@ logger = logging.getLogger(__name__)
 
 def get_position(id, jwt_token):
     '''
-    Gets an indivdual unavailable position by id
+    Gets an individual unavailable position by id
     '''
     return services.get_individual(
         "Positions",
-        id,
+        {"id": id},
         convert_pos_query,
         jwt_token,
         fsbid_pos_to_talentmap_pos

--- a/talentmap_api/fsbid/services/positions.py
+++ b/talentmap_api/fsbid/services/positions.py
@@ -1,6 +1,8 @@
 import logging
 from urllib.parse import urlencode, quote
 
+import pydash
+
 from talentmap_api.fsbid.services import common as services
 
 

--- a/talentmap_api/fsbid/services/projected_vacancies.py
+++ b/talentmap_api/fsbid/services/projected_vacancies.py
@@ -23,7 +23,7 @@ def get_projected_vacancy(id, jwt_token):
 
     args = {
         "uri": "",
-        "id": id,
+        "query": {"id": id},
         "query_mapping_function": convert_pv_query,
         "jwt_token": jwt_token,
         "mapping_function": fsbid_pv_to_talentmap_pv,

--- a/talentmap_api/fsbid/services/projected_vacancies.py
+++ b/talentmap_api/fsbid/services/projected_vacancies.py
@@ -20,20 +20,23 @@ def get_projected_vacancy(id, jwt_token):
     '''
     Gets an indivdual projected vacancy by id
     '''
-
     args = {
         "uri": "",
         "query": {"id": id},
         "query_mapping_function": convert_pv_query,
         "jwt_token": jwt_token,
         "mapping_function": fsbid_pv_to_talentmap_pv,
+        "count_function": None,
         "use_post": True,
+        "base_url": "/api/v1/fsbid/projected_vacancies/",
         "api_root": PV_API_V2_URL,
     }
 
-    return services.get_individual(
+    pv = services.send_get_request(
         **args
     )
+
+    return pydash.get(pv, 'results[0]') or None
 
 
 def get_projected_vacancies(query, jwt_token, host=None):

--- a/talentmap_api/fsbid/views/agenda.py
+++ b/talentmap_api/fsbid/views/agenda.py
@@ -37,7 +37,7 @@ class AgendaItemListView(BaseView):
 
     def get(self, request):
         '''
-        Gets all Agenda Items for a CDO/AO
+        Gets all Agenda Items
         '''
         return Response(services.get_agenda_items(request.META['HTTP_JWT'], request.query_params, f"{request.scheme}://{request.get_host()}"))
 
@@ -45,9 +45,15 @@ class AgendaItemListView(BaseView):
 class AgendaItemCSVView(BaseView):
     permission_classes = [Or(isDjangoGroupMember('cdo'), isDjangoGroupMember('ao_user'),)]
 
+    @swagger_auto_schema(
+        manual_parameters=[
+            openapi.Parameter("perdet", openapi.IN_QUERY, type=openapi.TYPE_INTEGER, description='Perdet of the Employee.'),
+            openapi.Parameter("ordering", openapi.IN_QUERY, type=openapi.TYPE_STRING, description='Which field to use when ordering the results.'),
+        ])
+
     def get(self, request):
         """
-        Return a list of all of the items in Agenda Item History for CSV export
+        Return a list of Agenda Items for CSV export
         """
         return services.get_agenda_item_history_csv(request.query_params, request.META['HTTP_JWT'], f"{request.scheme}://{request.get_host()}")
 

--- a/talentmap_api/fsbid/views/agenda.py
+++ b/talentmap_api/fsbid/views/agenda.py
@@ -18,13 +18,6 @@ logger = logging.getLogger(__name__)
 class AgendaItemView(BaseView):
     permission_classes = [Or(isDjangoGroupMember('cdo'), isDjangoGroupMember('ao_user'),)]
 
-    @swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter("ordering", openapi.IN_QUERY, type=openapi.TYPE_STRING, description='Which field to use when ordering the results.'),
-            openapi.Parameter("page", openapi.IN_QUERY, type=openapi.TYPE_INTEGER, description='A page number within the paginated result set.'),
-            openapi.Parameter("limit", openapi.IN_QUERY, type=openapi.TYPE_INTEGER, description='Number of results to return per page.'),
-        ])
-
     def get(self, request, pk):
         '''
         Get single agenda by ai_seq_num


### PR DESCRIPTION
## Refactoring get_individual

- [x] agenda/agenda_items/(?P<pk>[0-9]+)/$
- [x] agenda/agenda_items/export/ (updated and fixed)
- [x] cdo/client/(?P<client_id>[0-9]+)/$
- [x] available_positions/(?P<pk>[0-9]+)/similar/
- [x] available_positions/archived/(?P<pk>[0-9]+)/ (updated, but still broken - but at least breaks match)
- [x] bureau/positions/(?P<pk>[0-9]+)/ ~(i think also broken, but again, consistent)~ not broken, thanks Scott!
- [x] positions/(?P<pk>[0-9]+)/
- [x] projected_vacancies/(?P<pk>[0-9]+)/


jumped between dev and this branch to confirm urls and their payloads were identical


# Current Status: Complete