### PR TITLE
Employee Agenda Search - Case Insensitive Free Text Search for Employee ID TM-2803

### DIFF
--- a/talentmap_api/fsbid/services/agenda_employees.py
+++ b/talentmap_api/fsbid/services/agenda_employees.py
@@ -148,6 +148,7 @@ def convert_agenda_employees_query(query):
         # employee IDs can contain letters, and names can contain numbers. This does a best guess at the user's intent
         if len(''.join(re.findall('[0-9]+', qFilterValue))) > 2:
             qFilterKey = 'tmperpertexternalid'
+            qFilterValue = qFilterValue.upper()
         else:
             qFilterKey = 'tmperperfullname'
             qComparator = 'contains'


### PR DESCRIPTION
If you do an employee agenda search by 'a012345', it should return the user with id 'A012345'. The ID specific search should be case-insensitive. 

Tested Successfully in Dev1