### PR TITLE
bid tracker export clean up TM-3021

### DIFF
--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -523,10 +523,16 @@ def get_bids_csv(data, filename, jwt_token):
         "closed": "Closed",
         "draft": "Draft",
         "handshake_accepted": "Handshake Accepted",
+        "handshake_needs_registered": "Handshake Needs Registered",
         "handshake_with_another_bidder": "Handshake Registered With Another Bidder",
         "in_panel": "In Panel",
         "submitted": "Submitted",
     }
+
+    bid_status_list = [ 
+        "handshake_needs_registered",
+        "submitted",
+    ]
 
     for record in data:
         if pydash.get(record, 'position_info') is not None:
@@ -539,7 +545,7 @@ def get_bids_csv(data, filename, jwt_token):
             status = pydash.get(record, "status") or 'N/A'
             hs_offered_bid_status = status
 
-            if hs_offered == "Yes" and status == "submitted":
+            if hs_offered == "Yes" and status in bid_status_list:
                 hs_offered_bid_status = "handshake_with_another_bidder"
             
             hs_status = (pydash.get(record, 'handshake.hs_status_code') or '').replace('_', ' ') or 'N/A'

--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -493,6 +493,7 @@ def get_bids_csv(data, filename, jwt_token):
 
     # write the headers
     headers = []
+    headers.append(smart_str(u"Bid Status"))
     headers.append(smart_str(u"Position"))
     headers.append(smart_str(u"Position Number"))
     headers.append(smart_str(u"Skill"))
@@ -504,14 +505,12 @@ def get_bids_csv(data, filename, jwt_token):
     headers.append(smart_str(u"Languages"))
     headers.append(smart_str(u"Service Need Differential"))
     headers.append(smart_str(u"Hard to Fill"))
-    headers.append(smart_str(u"Handshake Offered"))
     headers.append(smart_str(u"Difficult to Staff"))
     headers.append(smart_str(u"Post Differential"))
     headers.append(smart_str(u"Danger Pay"))
     headers.append(smart_str(u"TED"))
     headers.append(smart_str(u"Incumbent"))
     headers.append(smart_str(u"Bid Cycle"))
-    headers.append(smart_str(u"Bid Status"))
     headers.append(smart_str(u"Handshake Status"))
     headers.append(smart_str(u"Bid Updated by CDO"))
     headers.append(smart_str(u"Bid Count"))
@@ -519,14 +518,46 @@ def get_bids_csv(data, filename, jwt_token):
 
     writer.writerow(headers)
 
+    bid_status = {
+        "approved": "Approved",
+        "closed": "Closed",
+        "draft": "Draft",
+        "declined": "Declined",
+        "handshake_accepted": "Handshake Accepted",
+        "handshake_declined": "Handshake Declined",
+        "handshake_needs_registered": "Handshake Needs Registered",
+        "handshake_with_another_bidder": "Handshake Registered With Another Bidder",
+        "in_panel": "In Panel",
+        "submitted": "Submitted",
+        "N/A": "N/A",
+    }
+
+    bid_status_list = [ 
+        "declined",
+        "handshake_declined",
+        "handshake_needs_registered",
+        "submitted",
+    ]
+
     for record in data:
         if pydash.get(record, 'position_info') is not None:
             try:
                 ted = smart_str(maya.parse(pydash.get(record, 'position_info.ted')).datetime().strftime('%m/%d/%Y'))
             except:
                 ted = "None listed"
+
+            hs_offered = mapBool[pydash.get(record, 'position_info.bid_statistics[0].has_handshake_offered')]
+            status = pydash.get(record, "status") or 'N/A'
+            hs_offered_bid_status = status
+
+            if hs_offered == "Yes" and status == "draft":
+                hs_offered_bid_status = status
+            if hs_offered == "Yes" and status in bid_status_list:
+                hs_offered_bid_status = "handshake_with_another_bidder"
+            
             hs_status = (pydash.get(record, 'handshake.hs_status_code') or '').replace('_', ' ') or 'N/A'
             row = []
+            row.append(bid_status[hs_offered_bid_status])
             row.append(smart_str(pydash.get(record, 'position_info.position.title')))
             row.append(smart_str("=\"%s\"" % pydash.get(record, 'position_info.position.position_number')))
             row.append(smart_str(pydash.get(record, 'position_info.position.skill')))
@@ -538,17 +569,12 @@ def get_bids_csv(data, filename, jwt_token):
             row.append(smart_str(parseLanguagesString(pydash.get(record, 'position_info.position.languages'))))
             row.append(mapBool[pydash.get(record, 'position_info.isServiceNeedDifferential')])
             row.append(mapBool[pydash.get(record, 'position_info.isHardToFill')])
-            row.append(mapBool[pydash.get(record, 'position_info.bid_statistics[0].has_handshake_offered')])
             row.append(mapBool[pydash.get(record, 'position_info.isDifficultToStaff')])
             row.append(smart_str(pydash.get(record, 'position_info.position.post.differential_rate')))
             row.append(smart_str(pydash.get(record, 'position_info.position.post.danger_pay')))
             row.append(ted)
             row.append(smart_str(pydash.get(record, 'position_info.position.current_assignment.user')))
             row.append(smart_str(pydash.get(record, 'position_info.bidcycle.name')))
-            if pydash.get(record, "status") == "handshake_accepted":
-                row.append(smart_str("handshake_registered"))
-            else:
-                row.append(smart_str(pydash.get(record, "status") or 'N/A'))
             row.append(hs_status)
             row.append(mapBool[pydash.get(record, "handshake.hs_cdo_indicator", 'default')])
             row.append(get_bid_stats_for_csv(pydash.get(record, 'position_info')))

--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -526,8 +526,10 @@ def get_bids_csv(data, filename, jwt_token):
         "handshake_accepted": "Handshake Accepted",
         "handshake_declined": "Handshake Declined",
         "handshake_needs_registered": "Handshake Needs Registered",
+        "handshake_offered": "Handshake Offered",
         "handshake_with_another_bidder": "Handshake Registered With Another Bidder",
         "in_panel": "In Panel",
+        "pre_panel": "Pre Panel",
         "submitted": "Submitted",
         "N/A": "N/A",
     }
@@ -536,6 +538,7 @@ def get_bids_csv(data, filename, jwt_token):
         "declined",
         "handshake_declined",
         "handshake_needs_registered",
+        "handshake_offered"
         "submitted",
     ]
 

--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -553,8 +553,6 @@ def get_bids_csv(data, filename, jwt_token):
             status = pydash.get(record, "status") or 'N/A'
             hs_offered_bid_status = status
 
-            if hs_offered == "Yes" and status == "draft":
-                hs_offered_bid_status = status
             if hs_offered == "Yes" and status in bid_status_list:
                 hs_offered_bid_status = "handshake_with_another_bidder"
             

--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -522,25 +522,11 @@ def get_bids_csv(data, filename, jwt_token):
         "approved": "Approved",
         "closed": "Closed",
         "draft": "Draft",
-        "declined": "Declined",
         "handshake_accepted": "Handshake Accepted",
-        "handshake_declined": "Handshake Declined",
-        "handshake_needs_registered": "Handshake Needs Registered",
-        "handshake_offered": "Handshake Offered",
         "handshake_with_another_bidder": "Handshake Registered With Another Bidder",
         "in_panel": "In Panel",
-        "pre_panel": "Pre Panel",
         "submitted": "Submitted",
-        "N/A": "N/A",
     }
-
-    bid_status_list = [ 
-        "declined",
-        "handshake_declined",
-        "handshake_needs_registered",
-        "handshake_offered"
-        "submitted",
-    ]
 
     for record in data:
         if pydash.get(record, 'position_info') is not None:
@@ -553,7 +539,7 @@ def get_bids_csv(data, filename, jwt_token):
             status = pydash.get(record, "status") or 'N/A'
             hs_offered_bid_status = status
 
-            if hs_offered == "Yes" and status in bid_status_list:
+            if hs_offered == "Yes" and status == "submitted":
                 hs_offered_bid_status = "handshake_with_another_bidder"
             
             hs_status = (pydash.get(record, 'handshake.hs_status_code') or '').replace('_', ' ') or 'N/A'

--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -550,7 +550,7 @@ def get_bids_csv(data, filename, jwt_token):
             
             hs_status = (pydash.get(record, 'handshake.hs_status_code') or '').replace('_', ' ') or 'N/A'
             row = []
-            row.append(bid_status[hs_offered_bid_status])
+            row.append(pydash.get(bid_status, hs_offered_bid_status) or 'N/A')
             row.append(smart_str(pydash.get(record, 'position_info.position.title')))
             row.append(smart_str("=\"%s\"" % pydash.get(record, 'position_info.position.position_number')))
             row.append(smart_str(pydash.get(record, 'position_info.position.skill')))


### PR DESCRIPTION
[FE PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2170)
To-do:

- [x] Make Bid Status the first column
- [x] Update Bid Status Column with combined HS Offered & Bid Status result to clearly state the status of the bid
- [x] Remove underscores from Bid Status row data, ie: "handshake_accepted" is now "Handshake Accepted"
- [x] Remove Handshake Offered Column


**Testing Checklist**
When the HS on the position is registered with the current bidder. Expected result in the export should be:
**status is case sensitive**
BE status: Export Value
- [x] "approved": "Approved"
- [x] "closed": "Closed"
- [x] "draft": "Draft"
- [x] "handshake_accepted": "Handshake Accepted"
- [x] "in_panel": "In Panel"
- [x] "pre_panel": "Pre Panel"

When the position **does** have the HS indicator, but the HS is with another bidder. Expected result in the export should be:
**status is case sensitive**
BE status: Export Value
- [x] "closed": "Closed"
- [x] "draft": "Draft"
- [x] "declined": "Handshake Registered With Another Bidder"
- [x] "handshake_declined": "Handshake Registered With Another Bidder"
- [x] "handshake_needs_registered": "Handshake Registered With Another Bidder"
- [x] "handshake_offered": "Handshake Offered"
- [x] "submitted": "Handshake Registered With Another Bidder"


When the position **does not** have the HS indicator. Expected result in the export should be:
**status is case sensitive**
BE status: Export Value
- [x] "closed": "Closed",
- [x] "draft": "Draft",
- [x] "declined": "Declined",
- [x] "handshake_declined": "Handshake Declined",
- [x] "handshake_needs_registered": "Handshake Needs Registered",
- [x] "handshake_offered": "Handshake Offered"
- [x] "submitted": "Submitted",