### PR TITLE
fix abl bureau dropdown data TM-3084

### DIFF
--- a/talentmap_api/fsbid/services/client.py
+++ b/talentmap_api/fsbid/services/client.py
@@ -516,7 +516,7 @@ def fsbid_assignments_to_tmap(assignments):
                         "skill": f"{pos.get('pos_skill_desc', None)} ({pos.get('pos_skill_code')})",
                         "skill_code": pos.get("pos_skill_code", None),
                         "bureau": f"({pos.get('pos_bureau_short_desc', None)}) {pos.get('pos_bureau_long_desc', None)}",
-                        "bureau_code": pydash.get(pos, 'bureau.bureau_short_desc'), # only comes through for available bidders
+                        "bureau_code": pydash.get(pos, 'pos_bureau_short_desc'), # only comes through for available bidders
                         "organization": pos.get('pos_org_short_desc', None),
                         "position_number": pos.get('pos_num_text', None),
                         "position_id": x.get('pos_seq_num', None),


### PR DESCRIPTION
The Bureau dropdown option is showing as `None listed` in DEV1 and upper envs. 

To-do
- [x] Update `get` for `bureau_code` to pull the correct data



**Note: Mock is not setup for this change yet. Results will show `None listed` in Local/AWS, however this should work properly in DEV1 and beyond.
The code below is already working in DEV1 and we only want the `short_desc` now for the `bureau_code` key
`"bureau": f"({pos.get('pos_bureau_short_desc', None)}) {pos.get('pos_bureau_long_desc', None)}",`**

**_I have verified that the data is appearing properly in DEV1 Swagger as well_**
