### PR TITLE
op/pv tandem position number sort TM-3050

### DIFF
--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -141,7 +141,7 @@ sort_dict = {
     "position__grade": "pos_grade_code",
     "position__bureau": "pos_bureau_short_desc",
     "ted": "ted",
-    "position__position_number": "pos_num_text",
+    "position__position_number": "position",
     "posted_date": "cp_post_dt",
     "skill": "skill",
     "grade": "grade",


### PR DESCRIPTION
To-do

- [x] update position number sort to handle `position` instead of `pos_num_text`