### PR TITLE
ted override error handling TM-3239

### DIFF
--- a/talentmap_api/common/common_helpers.py
+++ b/talentmap_api/common/common_helpers.py
@@ -188,7 +188,10 @@ def ensure_date(date, utc_offset=0):
             logger.warn(f"Parameter {date} must be a date object or string")
             return None
     except ValueError:
-        return "Invalid date"
+        try:
+            return parser.parse(date + '.000Z').astimezone(datetime.timezone.utc) - datetime.timedelta(hours=utc_offset)
+        except:
+            return "Invalid date"
 
 
 def validate_filters_exist(filter_list, filter_class):

--- a/talentmap_api/common/common_helpers.py
+++ b/talentmap_api/common/common_helpers.py
@@ -177,15 +177,18 @@ def ensure_date(date, utc_offset=0):
     Returns:
         - date (Object) - Datetime
     '''
-    if not date:
-        return None
-    elif isinstance(date, str):
-        return parser.parse(date).astimezone(datetime.timezone.utc) - datetime.timedelta(hours=utc_offset)
-    elif isinstance(date, datetime.date):
-        return date.astimezone(datetime.timezone(datetime.timedelta(hours=utc_offset)))
-    else:
-        logger.warn(f"Parameter {date} must be a date object or string")
-        return None
+    try:
+        if not date:
+            return None
+        elif isinstance(date, str):
+            return parser.parse(date).astimezone(datetime.timezone.utc) - datetime.timedelta(hours=utc_offset)
+        elif isinstance(date, datetime.date):
+            return date.astimezone(datetime.timezone(datetime.timedelta(hours=utc_offset)))
+        else:
+            logger.warn(f"Parameter {date} must be a date object or string")
+            return None
+    except ValueError:
+        return "Invalid date"
 
 
 def validate_filters_exist(filter_list, filter_class):

--- a/talentmap_api/fsbid/services/projected_vacancies.py
+++ b/talentmap_api/fsbid/services/projected_vacancies.py
@@ -161,7 +161,13 @@ def fsbid_pv_to_talentmap_pv(pv):
     '''
     Converts the response projected vacancy from FSBid to a format more in line with the Talentmap position
     '''
-    ted = ensure_date(pv.get("fv_override_ted_date", None), utc_offset=-5)
+    # error handling for bad date returned from WS
+    # fv_override_ted_date = "0001-01-01T00:00:00"
+    fv_override_ted_date = pv.get("fv_override_ted_date", None)
+    if fv_override_ted_date == "0001-01-01T00:00:00":
+        ted = ensure_date("0001-01-01T00:00:00.000Z", utc_offset=-5)
+
+    ted = ensure_date(fv_override_ted_date, utc_offset=-5)
     if ted is None:
         ted = ensure_date(pv.get("ted", None), utc_offset=-5)
     skill2 = services.get_secondary_skill(pv)

--- a/talentmap_api/fsbid/services/projected_vacancies.py
+++ b/talentmap_api/fsbid/services/projected_vacancies.py
@@ -161,14 +161,7 @@ def fsbid_pv_to_talentmap_pv(pv):
     '''
     Converts the response projected vacancy from FSBid to a format more in line with the Talentmap position
     '''
-    # error handling for bad date returned from WS
-    # fv_override_ted_date = "0001-01-01T00:00:00"
-    fv_override_ted_date = pv.get("fv_override_ted_date", None)
-    if fv_override_ted_date == "0001-01-01T00:00:00":
-        fv_override_ted_date = fv_override_ted_date + '.000Z'
-        ted = ensure_date(fv_override_ted_date, utc_offset=-5)
-
-    ted = ensure_date(fv_override_ted_date, utc_offset=-5)
+    ted = ensure_date(pv.get("fv_override_ted_date", None), utc_offset=-5)
     if ted is None:
         ted = ensure_date(pv.get("ted", None), utc_offset=-5)
     skill2 = services.get_secondary_skill(pv)

--- a/talentmap_api/fsbid/services/projected_vacancies.py
+++ b/talentmap_api/fsbid/services/projected_vacancies.py
@@ -165,7 +165,8 @@ def fsbid_pv_to_talentmap_pv(pv):
     # fv_override_ted_date = "0001-01-01T00:00:00"
     fv_override_ted_date = pv.get("fv_override_ted_date", None)
     if fv_override_ted_date == "0001-01-01T00:00:00":
-        ted = ensure_date("0001-01-01T00:00:00.000Z", utc_offset=-5)
+        fv_override_ted_date = fv_override_ted_date + '.000Z'
+        ted = ensure_date(fv_override_ted_date, utc_offset=-5)
 
     ted = ensure_date(fv_override_ted_date, utc_offset=-5)
     if ted is None:


### PR DESCRIPTION
In short, the date "0001-01-01T00:00:00" is being returned by WS and is throwing `ValueError: year 0 is out of range`.

The datetime function is looking/handling a lot of things. It is expecting certain ranges to be met (ie: only 12 months so you can't have `13-13-13` as a date even though the year and day are valid, etc.). With that being the case, this PR attempts to create a valid date out of a real but illogical date like the error we're receiving, but if it can't create the date at all it will show `Invalid date`. 

To-Do:

- [x] Display `01/01/0001` when `0001-01-01T00:00:00` is returned
- [x] Displays `Invalid date` when an unreal date like `01-32-32T000:00:00` is given or it can't handle the date 

Edge cases to manually test in the PV services file (order can be rearranged ie: 01-0001-01/add any number ie: 01-23-1234):
- "0001-01-01T00:00:00"
- "001-01-01T00:00:00"
- "01-01-01T00:00:00"
- Whatever your ❤️ desirers