### PR TITLE
remove updated from exteranl abl

### DIFF
--- a/talentmap_api/bureau/services/available_bidders.py
+++ b/talentmap_api/bureau/services/available_bidders.py
@@ -40,7 +40,6 @@ def get_available_bidders_csv(request):
         smart_str(u"Country"),
         smart_str(u"CDO Name"),
         smart_str(u"CDO Email"),
-        smart_str(u"Updated"),
     ])
 
     fields_info = {
@@ -52,7 +51,6 @@ def get_available_bidders_csv(request):
         "city": {"path": 'current_assignment.position.post.location.city', },
         "state": {"path": 'current_assignment.position.post.location.state', },
         "country": {"path": 'current_assignment.position.post.location.country', },
-        "updated_on": {"path": 'available_bidder_details.update_date', },
         "cdo_email": {"path": 'cdo.email', },
     }
 
@@ -66,10 +64,6 @@ def get_available_bidders_csv(request):
         cdo_name = f'{pydash.get(record, "cdo.last_name")}, {pydash.get(record, "cdo.first_name")}'
 
         fields = formatCSV(record, fields_info)
-
-        # Removing time zone text to allow Maya to parse
-        update_date, x, y = fields["updated_on"].partition('(')
-        update_date = maya.parse(update_date).datetime().strftime('%m/%d/%Y')
 
         try:
             ted = maya.parse(fields["ted"]).datetime().strftime('%m/%d/%Y')
@@ -87,6 +81,5 @@ def get_available_bidders_csv(request):
             fields["country"],
             cdo_name,
             fields["cdo_email"],
-            update_date,
         ])
     return response


### PR DESCRIPTION
Reverting changes from this [PR](https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/719)

Dual Merge: 
- [FE PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2361)

To-do:
- [x] remove `Updated` data from External CDA View export for Internal CDA Users (AO/CDO)
- [x] remove `Updated` data from External CDA Users (Bureau/Post) export

**These changes are being undone per the request of the PO**