### PR TITLE
update greenlet version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ freezegun==0.3.10
 future==0.16.0
 gitdb2==2.0.3
 GitPython==2.1.7
-greenlet==0.4.17
+greenlet==2.0.0
 idna==2.6
 isodate==0.6.0
 itsdangerous==2.0.1


### PR DESCRIPTION
Before:
gevent>=1.2.2
Downloads: gevent-22.8.0.tar.gz
"gevent 22.8.0 has requirement greenlet<2.0,>=1.1.3, but you'll have greenlet 0.4.17 which is incompatible."
[Successful Output](https://circleci.com/api/v1.1/project/github/MetaPhase-Consulting/State-TalentMAP-API/17439/output/103/0?file=true&allocation-id=63481f92ac033d08baf48f49-0-build%2F19913F92)



After:
gevent>=1.2.2
Downloads: gevent-22.10.2.tar.gz
greenlet throws error
[Fail Output](https://circleci.com/api/v1.1/project/github/MetaPhase-Consulting/State-TalentMAP-API/17486/output/103/0?file=true&allocation-id=63693fb71f20b925f817e62c-0-build%2F885781B)