### PR TITLE
TM-3832: Adding support for split name search

### DIFF
--- a/talentmap_api/fsbid/services/agenda_employees.py
+++ b/talentmap_api/fsbid/services/agenda_employees.py
@@ -156,7 +156,7 @@ def convert_agenda_employees_query(query):
         # TODO: Transition to search on new WS fields first name and last name instead of both on full name
         {"col": "tmperperfullname", "com": "CONTAINS", "val": query.get("firstName", None)},
         {"col": "tmperperfullname", "com": "CONTAINS", "val": query.get("lastName", None)},
-        {"col": "tmperpertexternalid", "com": "CONTAINS", "val": query.get("empID", None)}
+        {"col": "tmperpertexternalid", "com": "EQ", "val": query.get("empID", None)}
     ]
 
     if query.get("handshake", None):


### PR DESCRIPTION
ACs:
1. Verify filters being sent from backend to Web Services follows the same structure as below:
`tmperperfullname|CONTAINS|[first name/last name]`
`tmperpertexternalid|CONTAINS|[employee ID]`

2. Verify search works in DEV1

Dual Merge: 
- [FE PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2433)