### PR TITLE
TM-3832 Fix: Adding back .upper() functionality

### DIFF
--- a/talentmap_api/fsbid/services/agenda_employees.py
+++ b/talentmap_api/fsbid/services/agenda_employees.py
@@ -144,6 +144,10 @@ def convert_agenda_employees_query(query):
     
     tedStart = query.get("ted-start")
     tedEnd = query.get("ted-end")
+
+    firstName = query.get("firstName", None)
+    lastName = query.get("lastName", None)
+    empID = query.get("empID", None)
     
     filters = [
         {"col": "tmpercurrentbureaucode", "com": "IN", "val": query.get("current-bureaus", None)},
@@ -154,9 +158,9 @@ def convert_agenda_employees_query(query):
         {"col": "tmperperscode", "com": "IN", "val": "S,L,A,P,U"},
         {"col": "tmperperdetseqnum", "com": "EQ", "val": query.get("perdet", None)},
         # TODO: Transition to search on new WS fields first name and last name instead of both on full name
-        {"col": "tmperperfullname", "com": "CONTAINS", "val": query.get("firstName", None)},
-        {"col": "tmperperfullname", "com": "CONTAINS", "val": query.get("lastName", None)},
-        {"col": "tmperpertexternalid", "com": "EQ", "val": query.get("empID", None)}
+        {"col": "tmperperfullname", "com": "CONTAINS", "val": firstName.upper() if firstName != None else None},
+        {"col": "tmperperfullname", "com": "CONTAINS", "val": lastName.upper() if lastName != None else None},
+        {"col": "tmperpertexternalid", "com": "EQ", "val": empID.upper() if empID != None else None}
     ]
 
     if query.get("handshake", None):

--- a/talentmap_api/fsbid/services/agenda_employees.py
+++ b/talentmap_api/fsbid/services/agenda_employees.py
@@ -145,9 +145,9 @@ def convert_agenda_employees_query(query):
     tedStart = query.get("ted-start")
     tedEnd = query.get("ted-end")
 
-    firstName = query.get("firstName", None)
-    lastName = query.get("lastName", None)
-    empID = query.get("empID", None)
+    firstName = query.get("firstName").upper() if query.get("firstName") else query.get("firstName")
+    lastName = query.get("lastName").upper() if query.get("lastName") else query.get("lastName")
+    empID = query.get("empID").upper() if query.get("empID") else query.get("empID")
     
     filters = [
         {"col": "tmpercurrentbureaucode", "com": "IN", "val": query.get("current-bureaus", None)},
@@ -158,9 +158,9 @@ def convert_agenda_employees_query(query):
         {"col": "tmperperscode", "com": "IN", "val": "S,L,A,P,U"},
         {"col": "tmperperdetseqnum", "com": "EQ", "val": query.get("perdet", None)},
         # TODO: Transition to search on new WS fields first name and last name instead of both on full name
-        {"col": "tmperperfullname", "com": "CONTAINS", "val": firstName.upper() if firstName != None else None},
-        {"col": "tmperperfullname", "com": "CONTAINS", "val": lastName.upper() if lastName != None else None},
-        {"col": "tmperpertexternalid", "com": "EQ", "val": empID.upper() if empID != None else None}
+        {"col": "tmperperfullname", "com": "CONTAINS", "val": firstName},
+        {"col": "tmperperfullname", "com": "CONTAINS", "val": lastName},
+        {"col": "tmperpertexternalid", "com": "EQ", "val": empID}
     ]
 
     if query.get("handshake", None):


### PR DESCRIPTION
ACs:
1. Verify filters being sent from backend to Web Services follows the same structure as below:
`tmperperfullname|CONTAINS|[first name/last name]` with the last/first name being all caps
`tmperpertexternalid|EQ|[employee ID]` with the letters within the employee ID capitalized

<img width="1215" alt="image" src="https://user-images.githubusercontent.com/31417027/213052832-d437f0cf-9f72-4a9f-8902-c766c312dbf5.png">
