### PR TITLE
TM-3849: Employee Agenda Search Inactive Employees Toggle

### DIFF
--- a/talentmap_api/fsbid/services/agenda_employees.py
+++ b/talentmap_api/fsbid/services/agenda_employees.py
@@ -149,7 +149,7 @@ def convert_agenda_employees_query(query):
     lastName = query.get("lastName").upper() if query.get("lastName") else query.get("lastName")
     empID = query.get("empID").upper() if query.get("empID") else query.get("empID")
 
-    inactiveIsSelected = query.get("inactiveIsSelected")
+    isInactiveSelected = "S,L,A,P,U" if not query.get("isInactiveSelected") else None
     
     filters = [
         {"col": "tmpercurrentbureaucode", "com": "IN", "val": query.get("current-bureaus", None)},
@@ -157,7 +157,7 @@ def convert_agenda_employees_query(query):
         {"col": "tmpercurrentorgcode", "com": "IN", "val": query.get("current-organizations", None)},
         {"col": "tmperhsorgcode", "com": "IN", "val": query.get("handshake-organizations", None)},
         {"col": "tmpercdoid", "com": "IN", "val": query.get("cdos", None)},
-        {"col": "tmperperscode", "com": "IN", "val": "S,L,A,P,U" if not inactiveIsSelected else None},
+        {"col": "tmperperscode", "com": "IN", "val": isInactiveSelected},
         {"col": "tmperperdetseqnum", "com": "EQ", "val": query.get("perdet", None)},
         # TODO: Transition to search on new WS fields first name and last name instead of both on full name
         {"col": "tmperperfullname", "com": "CONTAINS", "val": firstName},

--- a/talentmap_api/fsbid/services/agenda_employees.py
+++ b/talentmap_api/fsbid/services/agenda_employees.py
@@ -141,8 +141,6 @@ def convert_agenda_employees_query(query):
     '''
     Convert TalentMAP filters into FSBid filters
     '''
-    # print('===query===')
-    # print(query)
     
     tedStart = query.get("ted-start")
     tedEnd = query.get("ted-end")
@@ -190,8 +188,6 @@ def convert_agenda_employees_query(query):
     filters = pydash.filter_(filters, lambda o: o["val"] != None)
 
     filters = services.convert_to_fsbid_ql(filters)
-    print('===filters===')
-    print(filters)
 
     values = {
         # Pagination

--- a/talentmap_api/fsbid/services/agenda_employees.py
+++ b/talentmap_api/fsbid/services/agenda_employees.py
@@ -141,6 +141,8 @@ def convert_agenda_employees_query(query):
     '''
     Convert TalentMAP filters into FSBid filters
     '''
+    # print('===query===')
+    # print(query)
     
     tedStart = query.get("ted-start")
     tedEnd = query.get("ted-end")
@@ -148,6 +150,8 @@ def convert_agenda_employees_query(query):
     firstName = query.get("firstName").upper() if query.get("firstName") else query.get("firstName")
     lastName = query.get("lastName").upper() if query.get("lastName") else query.get("lastName")
     empID = query.get("empID").upper() if query.get("empID") else query.get("empID")
+
+    inactiveIsSelected = query.get("inactiveIsSelected")
     
     filters = [
         {"col": "tmpercurrentbureaucode", "com": "IN", "val": query.get("current-bureaus", None)},
@@ -155,7 +159,7 @@ def convert_agenda_employees_query(query):
         {"col": "tmpercurrentorgcode", "com": "IN", "val": query.get("current-organizations", None)},
         {"col": "tmperhsorgcode", "com": "IN", "val": query.get("handshake-organizations", None)},
         {"col": "tmpercdoid", "com": "IN", "val": query.get("cdos", None)},
-        {"col": "tmperperscode", "com": "IN", "val": "S,L,A,P,U"},
+        {"col": "tmperperscode", "com": "IN", "val": "S,L,A,P,U" if not inactiveIsSelected else None},
         {"col": "tmperperdetseqnum", "com": "EQ", "val": query.get("perdet", None)},
         # TODO: Transition to search on new WS fields first name and last name instead of both on full name
         {"col": "tmperperfullname", "com": "CONTAINS", "val": firstName},
@@ -186,6 +190,8 @@ def convert_agenda_employees_query(query):
     filters = pydash.filter_(filters, lambda o: o["val"] != None)
 
     filters = services.convert_to_fsbid_ql(filters)
+    print('===filters===')
+    print(filters)
 
     values = {
         # Pagination

--- a/talentmap_api/fsbid/services/agenda_employees.py
+++ b/talentmap_api/fsbid/services/agenda_employees.py
@@ -149,7 +149,7 @@ def convert_agenda_employees_query(query):
     lastName = query.get("lastName").upper() if query.get("lastName") else query.get("lastName")
     empID = query.get("empID").upper() if query.get("empID") else query.get("empID")
 
-    isInactiveSelected = "S,L,A,P,U" if not query.get("isInactiveSelected") else None
+    activeCodes = "S,L,A,P,U" if not query.get("isInactiveSelected") else None
     
     filters = [
         {"col": "tmpercurrentbureaucode", "com": "IN", "val": query.get("current-bureaus", None)},
@@ -157,7 +157,7 @@ def convert_agenda_employees_query(query):
         {"col": "tmpercurrentorgcode", "com": "IN", "val": query.get("current-organizations", None)},
         {"col": "tmperhsorgcode", "com": "IN", "val": query.get("handshake-organizations", None)},
         {"col": "tmpercdoid", "com": "IN", "val": query.get("cdos", None)},
-        {"col": "tmperperscode", "com": "IN", "val": isInactiveSelected},
+        {"col": "tmperperscode", "com": "IN", "val": activeCodes},
         {"col": "tmperperdetseqnum", "com": "EQ", "val": query.get("perdet", None)},
         # TODO: Transition to search on new WS fields first name and last name instead of both on full name
         {"col": "tmperperfullname", "com": "CONTAINS", "val": firstName},


### PR DESCRIPTION
To verify on local, print `filters` in State-TalentMAP-API/talentmap_api/fsbid/services/agenda_employees.py `convert_agenda_employees_query`. Queries for filtered (active employees) should send back `tmperperscode|IN|A,L,P,S,U|` to the mock while unfiltered (active AND inactive employees) should not send that filter back. The `tmperperscode` filter is what differentiates active/inactive employees

Dual Merge: 
- [FE PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2438)
