### PR TITLE
TM-3905: adding new location fields to EP

### DIFF
--- a/talentmap_api/fsbid/services/agenda_employees.py
+++ b/talentmap_api/fsbid/services/agenda_employees.py
@@ -231,9 +231,13 @@ def fsbid_agenda_employee_to_talentmap_agenda_employee(data, cdos=[]):
         "currentAssignment": {
             "TED": pydash.get(data, "currentAssignment[0].asgdetdteddate", None),
             "orgDescription": pydash.get(data, "currentAssignment[0].position[0].posorgshortdesc", None),
+            "locationCity": pydash.get(data, "currentAssignment[0].position[0].location[0].loccity", None),
+            "locationCountry": pydash.get(data, "currentAssignment[0].position[0].location[0].loccountry", None),
         },
         "hsAssignment": {
             "orgDescription": pydash.get(data, "handshake[0].posorgshortdesc", None),
+            "hsLocationCity": pydash.get(data, "handshake[0].position[0].location[0].loccity", None),
+            "hsLocationCountry": pydash.get(data, "handshake[0].position[0].location[0].loccountry", None),
         },
         "agenda": {
             "panelDate": pydash.get(data, "latestAgendaItem[0].panels[0].pmddttm", None),


### PR DESCRIPTION
ACs:
1. Verify API is now accurately sending new location fields in the following format: City, Country (Org)

![image](https://user-images.githubusercontent.com/31417027/224420524-765c3ec9-45ff-43e8-8789-36240633cc0e.png)

Dual Merge: 
- [FE PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2488)
- [Mock PR](https://github.com/MetaPhase-Consulting/mock-fsbid/pull/355)