### PR TITLE
TM-4264, create URL to get employee name from tm persons endpoint

### DIFF
--- a/talentmap_api/fsbid/urls/agenda_employees.py
+++ b/talentmap_api/fsbid/urls/agenda_employees.py
@@ -8,6 +8,7 @@ router = routers.SimpleRouter()
 urlpatterns = [
     url(r'^$', views.FSBidAgendaEmployeesListView.as_view(), name="agenda-employees-FSBid-agenda-employees-list"),
     url(r'^export/$', views.FSBidAgendaEmployeesCSVView.as_view(), name="agenda-employees-FSBid-agenda-employees-export"),
+    url(r'^employee/(?P<pk>[0-9]+)$', views.FSBidAgendaEmployeeView.as_view(), name="agenda-employees-FSBid-agenda-employee"),
     url(r'^reference/current-organizations/$', views.FSBidPersonCurrentOrganizationsView.as_view(), name='agenda-employees-fsbid-reference-current-organizations'),
     url(r'^reference/handshake-organizations/$', views.FSBidPersonHandshakeOrganizationsView.as_view(), name='agenda-employees-fsbid-reference-hs-organizations'),
     url(r'^reference/current-bureaus/$', views.FSBidPersonCurrentBureausView.as_view(), name='agenda-employees-fsbid-reference-current-bureaus'),

--- a/talentmap_api/fsbid/views/agenda_employees.py
+++ b/talentmap_api/fsbid/views/agenda_employees.py
@@ -1,6 +1,7 @@
 import logging
 import pydash
 from rest_framework.response import Response
+from django.http import QueryDict
 
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
@@ -43,7 +44,17 @@ class FSBidAgendaEmployeesListView(BaseView):
         Gets all agenda employees
         '''
         return Response(services.get_agenda_employees(request.query_params, request.META['HTTP_JWT'], f"{request.scheme}://{request.get_host()}"))
+    
+class FSBidAgendaEmployeeView(BaseView):
+    
+    permission_classes = [Or(isDjangoGroupMember('ao_user'), isDjangoGroupMember('cdo')), ]
 
+    def get(self, request, pk):
+        '''
+        Get single employee data from tm-persons by perdetseqnum
+        '''
+        employeeQuery = QueryDict(f"limit=1&page=1&perdet={pk}")
+        return Response(services.get_agenda_employees(employeeQuery, request.META['HTTP_JWT'], f"{request.scheme}://{request.get_host()}"))
 
 class FSBidAgendaEmployeesCSVView(BaseView):
     


### PR DESCRIPTION
So we should be able to hit `/fsbid/agenda_employees/employee/${id}` on the frontend and have it hit `v1/tm-persons&limit=1&page=1&perdet={pk}` on the backend

I still need to double check this in Dev1, as i dont think our mock data can handle it - so it can't be tested locally. 

Please be thorough - there were clearly a few ways to go about this, but i just pattern matched what seemed easiest to replicate, for expedience. 

Lastly, I think we'll need to make a separate ticket for updating the Mock to handle this query (if need be) - my understanding is that it would be a PITA to make that update to the mock.

Dual Merge: 
- [FE PR] TBD
- [Mock PR] TBD