### PR TITLE
Add ep for asg history by logged in user

### DIFF
--- a/talentmap_api/fsbid/urls/assignment_history.py
+++ b/talentmap_api/fsbid/urls/assignment_history.py
@@ -7,6 +7,7 @@ router = routers.SimpleRouter()
 
 urlpatterns = [
     url(r'^(?P<pk>[0-9]+)/$', views.FSBidAssignmentHistoryListView.as_view(), name="assignment-history-list"),
+    url(r'^$', views.FSBidPrivateAssignmentHistoryListView.as_view(), name="private-assignment-history-list"),
 ]
 
 urlpatterns += router.urls

--- a/talentmap_api/fsbid/views/assignment_history.py
+++ b/talentmap_api/fsbid/views/assignment_history.py
@@ -8,6 +8,7 @@ from drf_yasg import openapi
 from rest_condition import Or
 
 from talentmap_api.fsbid.views.base import BaseView
+from talentmap_api.user_profile.models import UserProfile
 from talentmap_api.fsbid.services.assignment_history import get_assignments, assignment_history_to_client_format
 from talentmap_api.common.permissions import isDjangoGroupMember
 
@@ -30,6 +31,25 @@ class FSBidAssignmentHistoryListView(BaseView):
         '''
         query_copy = request.query_params.copy()
         query_copy["perdet_seq_num"] = pk 
+        query_copy._mutable = False
+        data = assignment_history_to_client_format(get_assignments(query_copy, request.META['HTTP_JWT']))
+        return Response(data)
+
+
+class FSBidPrivateAssignmentHistoryListView(BaseView):
+    @swagger_auto_schema(
+        manual_parameters=[
+            openapi.Parameter("page", openapi.IN_QUERY, type=openapi.TYPE_INTEGER, description='A page number within the paginated result set.'),
+            openapi.Parameter('limit', openapi.IN_QUERY, type=openapi.TYPE_INTEGER, description='Number of results to return per page.')
+        ])
+
+    def get(self, request):
+        '''
+        Gets current users assignment history
+        '''
+        user = UserProfile.objects.get(user=self.request.user)
+        query_copy = request.query_params.copy()
+        query_copy["perdet_seq_num"] = user.emp_id
         query_copy._mutable = False
         data = assignment_history_to_client_format(get_assignments(query_copy, request.META['HTTP_JWT']))
         return Response(data)


### PR DESCRIPTION
In order to avoid potential unauthorized lookups - created a nearly identical endpoint except it injects the perdet lookup based off the logged in user.

You can confirm this by using the CDO/AO role to view a client and their history, then use that same client persona to test swagger and ensure the payloads return generally the same content. Will be connected to FE to allow for public and private profile viewing of asg history. May need to update mapping to account for effective status etc.

Will need to update WS permissions for parent asg resource