### PR TITLE
TM-4265, add suffix to agenda search name

### DIFF
--- a/talentmap_api/fsbid/services/agenda_employees.py
+++ b/talentmap_api/fsbid/services/agenda_employees.py
@@ -210,6 +210,10 @@ def fsbid_agenda_employee_to_talentmap_agenda_employee(data, cdos=[]):
     firstN = data.get('perpiifirstname', '')
     lastN = data.get('perpiilastname', '')
     initials = f"{firstN[0] if firstN else ''}{lastN[0] if lastN else ''}"
+    suffix = data.get('perpiisuffixname', '')
+    hasSuffix = len(suffix) > 0
+    if suffix == " ":
+        hasSuffix = False
     fullName = data.get("perpiifullname", "")
     if pydash.ends_with(fullName, "NMN"):
         fullName = fullName.rstrip(" NMN")
@@ -222,7 +226,7 @@ def fsbid_agenda_employee_to_talentmap_agenda_employee(data, cdos=[]):
         cdo = cdoObj
     return {
         "person": {
-            "fullName": fullName,
+            "fullName": fullName + f"{', '+suffix if hasSuffix else ''} ",
             "perdet": data.get("perdetseqnum", ""),
             "employeeID": data.get("pertexternalid", ""),
             "initials": initials,

--- a/talentmap_api/fsbid/services/agenda_employees.py
+++ b/talentmap_api/fsbid/services/agenda_employees.py
@@ -211,9 +211,7 @@ def fsbid_agenda_employee_to_talentmap_agenda_employee(data, cdos=[]):
     lastN = data.get('perpiilastname', '')
     initials = f"{firstN[0] if firstN else ''}{lastN[0] if lastN else ''}"
     suffix = data.get('perpiisuffixname', '')
-    hasSuffix = len(suffix) > 0
-    if suffix == " ":
-        hasSuffix = False
+    hasSuffix = len(suffix.strip()) > 0
     fullName = data.get("perpiifullname", "")
     if pydash.ends_with(fullName, "NMN"):
         fullName = fullName.rstrip(" NMN")


### PR DESCRIPTION
This was shockingly tricky - we should definitely make a function and keep it somewhere - where we can pass in all the name data from any endpoint and have it return cleanly. 

Might also need to update the mock - but not a requirement 

From Dev:
<img width="813" alt="image" src="https://user-images.githubusercontent.com/12723877/232154007-ea23870c-2431-43f4-966f-bd8dcf66c7ce.png">
