### PR TITLE
denoting legacy remarks

### DIFF
--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -835,9 +835,9 @@ def categorize_remark(remark = ''):
 
 def parse_agenda_remarks(remarks=[]):
     remarks_values = []
-    if (remarks):
+    if remarks:
         for remark in remarks:
-            if (pydash.get(remark, 'remarkRefData[0].rmrktext') in [None, '']):
+            if pydash.get(remark, 'remarkRefData[0].rmrktext') in [None, '']:
                 if not pydash.get(remark, 'remarkInserts'):
                     continue
                 remark['remarkRefData'][0]['rmrktext'] = pydash.get(remark, 'remarkInserts')[0]['airiinsertiontext']
@@ -853,7 +853,7 @@ def parse_agenda_remarks(remarks=[]):
             refRemarkText = pydash.get(remark, 'remarkRefData[0].rmrktext')
             refInsertionsText = pydash.get(remark, 'remarkRefData[0].RemarkInserts')
 
-            if (remarkInsertions):
+            if remarkInsertions:
                 for insertion in remarkInsertions:
                     matchText = pydash.find(refInsertionsText, {'riseqnum': insertion['aiririseqnum']})
                     if (matchText):
@@ -862,6 +862,9 @@ def parse_agenda_remarks(remarks=[]):
                         continue
 
             remark['remarkRefData'][0]['rmrktext'] = refRemarkText
+            if remark['remarkRefData'][0]['rmrkactiveind'] == 'N':
+                remark['remarkRefData'][0]['rmrktext'] += ' (legacy)'
+
             pydash.unset(remark, 'remarkRefData[0].RemarkInserts')
             remarks_values.append(agendaservices.fsbid_to_talentmap_agenda_remarks(remark['remarkRefData'][0]))
 

--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from copy import deepcopy
 from functools import partial
 
+
 from django.conf import settings
 from django.db.models import Q
 from django.http import HttpResponse
@@ -38,12 +39,11 @@ FAVORITES_LIMIT = settings.FAVORITES_LIMIT
 PV_API_V2_URL = settings.PV_API_V2_URL
 CLIENTS_ROOT_V2 = settings.CLIENTS_API_V2_URL
 
+
 urls_expire_after = {
     '*/cycles': 30,
     '*': 0,  # Every other non-matching URL: do not cache
 }
-
-
 # session = requests_cache.CachedSession(backend='memory', namespace='tmap-cache', urls_expire_after=urls_expire_after)
 
 
@@ -117,7 +117,6 @@ def parseLanguagesString(lang):
 
         return lang_str
 
-
 def parseLanguagesToArr(data):
     '''
     Transforms flat language data into array.
@@ -169,7 +168,6 @@ def parseLanguagesToArr(data):
             })
 
     return languages
-
 
 def post_values(query):
     '''
@@ -233,6 +231,7 @@ sort_dict = {
     "bidlist_location": "position_info.position.post.location.city",
     "panel_date": "pmddttm",
 }
+
 
 mapBool = {True: 'Yes', False: 'No', 'default': '', None: 'N/A'}
 
@@ -349,7 +348,7 @@ def send_count_request(uri, query, query_mapping_function, jwt_token, host=None,
     countObj = pydash.get(response, "Data[0]")
     if len(pydash.keys(countObj)):
         count = pydash.get(countObj, pydash.keys(countObj)[0])
-        return {"count": count}
+        return { "count": count }
     else:
         logger.error(f"No count property could be found. {response}")
         raise KeyError('No count property could be found')
@@ -358,13 +357,11 @@ def send_count_request(uri, query, query_mapping_function, jwt_token, host=None,
 # pre-load since this data rarely changes
 obc_vals = list([])
 
-
 def get_obc_vals():
     global obc_vals
     if not obc_vals:
         obc_vals = list(Obc.objects.values())
     return obc_vals
-
 
 def get_obc_id(post_id):
     obc = pydash.find(get_obc_vals(), lambda x: x['code'] == post_id)
@@ -404,7 +401,7 @@ def send_get_csv_request(uri, query, query_mapping_function, jwt_token, mapping_
     formattedQuery = query
     try:
         formattedQuery._mutable = True
-    except:  # nosec
+    except:#nosec
         pass
 
     if ad_id is not None:
@@ -666,7 +663,7 @@ def has_competing_rank(jwt, perdet, pk):
     aps = []
     if rankOneBids:
         ids = ','.join(rankOneBids)
-        ap = apservices.get_available_positions({'id': ids, 'page': 1, 'limit': len(rankOneBids) or 1}, jwt)
+        ap = apservices.get_available_positions({ 'id': ids, 'page': 1, 'limit': len(rankOneBids) or 1 }, jwt)
         aps = pydash.map_(ap['results'], 'id')
 
     for y in aps:
@@ -737,7 +734,7 @@ def get_bidders_csv(self, pk, data, filename, jwt_token):
     return response
 
 
-def get_secondary_skill(pos={}):
+def get_secondary_skill(pos = {}):
     skillSecondary = f"{pos.get('pos_staff_ptrn_skill_desc', None)} ({pos.get('pos_staff_ptrn_skill_code')})"
     skillSecondaryCode = pos.get("pos_staff_ptrn_skill_code", None)
     if pos.get("pos_skill_code", None) == pos.get("pos_staff_ptrn_skill_code", None):
@@ -797,7 +794,7 @@ def sort_bids(bidlist, ordering_query):
             is_asc = pydash.get(ordering, '[1]') == 'asc'
             bids = sorted(bids, key=lambda x: pydash.get(x, order, '') or '', reverse=not is_asc)
         elif ordering_query in ('status', '-status'):
-            bids = pydash.map_(bids, lambda x: {**x, "ordering": bid_status_order[x['status']]})
+            bids = pydash.map_(bids, lambda x: { **x, "ordering": bid_status_order[x['status']] })
             bids = pydash.sort_by(bids, "ordering", reverse=ordering_query[0] == '-')
             bids = pydash.map_(bids, lambda x: pydash.omit(x, 'ordering'))
             bids.reverse()
@@ -829,8 +826,8 @@ def convert_to_fsbid_ql(filters):
     return formattedFilters
 
 
-def categorize_remark(remark=''):
-    obj = {'text': remark, 'type': None}
+def categorize_remark(remark = ''):
+    obj = { 'text': remark, 'type': None }
     if pydash.starts_with(remark, 'Creator') or pydash.starts_with(remark, 'CDO:') or pydash.starts_with(remark, 'Modifier'):
         obj['type'] = 'person'
     return obj
@@ -838,9 +835,9 @@ def categorize_remark(remark=''):
 
 def parse_agenda_remarks(remarks=[]):
     remarks_values = []
-    if remarks:
+    if (remarks):
         for remark in remarks:
-            if pydash.get(remark, 'remarkRefData[0].rmrktext') in [None, '']:
+            if (pydash.get(remark, 'remarkRefData[0].rmrktext') in [None, '']):
                 if not pydash.get(remark, 'remarkInserts'):
                     continue
                 remark['remarkRefData'][0]['rmrktext'] = pydash.get(remark, 'remarkInserts')[0]['airiinsertiontext']
@@ -856,7 +853,7 @@ def parse_agenda_remarks(remarks=[]):
             refRemarkText = pydash.get(remark, 'remarkRefData[0].rmrktext')
             refInsertionsText = pydash.get(remark, 'remarkRefData[0].RemarkInserts')
 
-            if remarkInsertions:
+            if (remarkInsertions):
                 for insertion in remarkInsertions:
                     matchText = pydash.find(refInsertionsText, {'riseqnum': insertion['aiririseqnum']})
                     if (matchText):
@@ -865,9 +862,6 @@ def parse_agenda_remarks(remarks=[]):
                         continue
 
             remark['remarkRefData'][0]['rmrktext'] = refRemarkText
-            if remark['remarkRefData'][0]['rmrkactiveind'] == 'N':
-                remark['remarkRefData'][0]['rmrktext'] += ' (legacy)'
-
             pydash.unset(remark, 'remarkRefData[0].RemarkInserts')
             remarks_values.append(agendaservices.fsbid_to_talentmap_agenda_remarks(remark['remarkRefData'][0]))
 
@@ -983,7 +977,7 @@ def csv_fsbid_template_to_tm(data, mapping):
     row = []
 
     for x in mapping['wskeys'].keys():
-        default = mapping['wskeys'][x]['default'] if 'default' in mapping['wskeys'][x] else mapping['default']
+        default =  mapping['wskeys'][x]['default'] if 'default' in mapping['wskeys'][x] else mapping['default']
 
         if 'transformFn' in mapping['wskeys'][x]:
             mapped = mapping['wskeys'][x]['transformFn'](pydash.get(data, x)) or default

--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -863,7 +863,7 @@ def parse_agenda_remarks(remarks=[]):
 
             remark['remarkRefData'][0]['rmrktext'] = refRemarkText
             if remark['remarkRefData'][0]['rmrkactiveind'] == 'N':
-                remark['remarkRefData'][0]['rmrktext'] = '(legacy) ' + remark['remarkRefData'][0]['rmrktext']
+                remark['remarkRefData'][0]['rmrktext'] = '(Legacy) ' + remark['remarkRefData'][0]['rmrktext']
 
             pydash.unset(remark, 'remarkRefData[0].RemarkInserts')
             remarks_values.append(agendaservices.fsbid_to_talentmap_agenda_remarks(remark['remarkRefData'][0]))

--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -863,7 +863,7 @@ def parse_agenda_remarks(remarks=[]):
 
             remark['remarkRefData'][0]['rmrktext'] = refRemarkText
             if remark['remarkRefData'][0]['rmrkactiveind'] == 'N':
-                remark['remarkRefData'][0]['rmrktext'] += ' (legacy)'
+                remark['remarkRefData'][0]['rmrktext'] = '(legacy) ' + remark['remarkRefData'][0]['rmrktext']
 
             pydash.unset(remark, 'remarkRefData[0].RemarkInserts')
             remarks_values.append(agendaservices.fsbid_to_talentmap_agenda_remarks(remark['remarkRefData'][0]))

--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -836,7 +836,7 @@ def categorize_remark(remark=''):
     return obj
 
 
-def parse_agenda_remarks(remarks=[]):
+def parse_agenda_remarks(remarks = []):
     remarks_values = []
     if remarks:
         for remark in remarks:
@@ -865,14 +865,14 @@ def parse_agenda_remarks(remarks=[]):
                         continue
 
             remark['remarkRefData'][0]['rmrktext'] = refRemarkText
-
             if remark['remarkRefData'][0]['rmrkactiveind'] == 'N':
                 remark['remarkRefData'][0]['rmrktext'] += ' (legacy)'
 
             pydash.unset(remark, 'remarkRefData[0].RemarkInserts')
             remarks_values.append(agendaservices.fsbid_to_talentmap_agenda_remarks(remark['remarkRefData'][0]))
-    
+
     return remarks_values
+
 
 def get_aih_csv(data, filename):
     filename = re.sub(r'(\_)\1+', r'\1', filename.replace(',', '_').replace(' ', '_').replace("'", '_'))

--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from copy import deepcopy
 from functools import partial
 
-
 from django.conf import settings
 from django.db.models import Q
 from django.http import HttpResponse
@@ -39,11 +38,12 @@ FAVORITES_LIMIT = settings.FAVORITES_LIMIT
 PV_API_V2_URL = settings.PV_API_V2_URL
 CLIENTS_ROOT_V2 = settings.CLIENTS_API_V2_URL
 
-
 urls_expire_after = {
     '*/cycles': 30,
     '*': 0,  # Every other non-matching URL: do not cache
 }
+
+
 # session = requests_cache.CachedSession(backend='memory', namespace='tmap-cache', urls_expire_after=urls_expire_after)
 
 
@@ -117,6 +117,7 @@ def parseLanguagesString(lang):
 
         return lang_str
 
+
 def parseLanguagesToArr(data):
     '''
     Transforms flat language data into array.
@@ -168,6 +169,7 @@ def parseLanguagesToArr(data):
             })
 
     return languages
+
 
 def post_values(query):
     '''
@@ -231,7 +233,6 @@ sort_dict = {
     "bidlist_location": "position_info.position.post.location.city",
     "panel_date": "pmddttm",
 }
-
 
 mapBool = {True: 'Yes', False: 'No', 'default': '', None: 'N/A'}
 
@@ -343,12 +344,12 @@ def send_count_request(uri, query, query_mapping_function, jwt_token, host=None,
     else:
         url = f"{api_root}/{uri}?{query_mapping_function(newQuery)}"
         method = requests.get
-    
+
     response = method(url, headers={'JWTAuthorization': jwt_token, 'Content-Type': 'application/json'}, **args).json()
     countObj = pydash.get(response, "Data[0]")
     if len(pydash.keys(countObj)):
         count = pydash.get(countObj, pydash.keys(countObj)[0])
-        return { "count": count }
+        return {"count": count}
     else:
         logger.error(f"No count property could be found. {response}")
         raise KeyError('No count property could be found')
@@ -357,11 +358,13 @@ def send_count_request(uri, query, query_mapping_function, jwt_token, host=None,
 # pre-load since this data rarely changes
 obc_vals = list([])
 
+
 def get_obc_vals():
     global obc_vals
     if not obc_vals:
         obc_vals = list(Obc.objects.values())
     return obc_vals
+
 
 def get_obc_id(post_id):
     obc = pydash.find(get_obc_vals(), lambda x: x['code'] == post_id)
@@ -401,7 +404,7 @@ def send_get_csv_request(uri, query, query_mapping_function, jwt_token, mapping_
     formattedQuery = query
     try:
         formattedQuery._mutable = True
-    except:#nosec
+    except:  # nosec
         pass
 
     if ad_id is not None:
@@ -439,7 +442,6 @@ def get_bid_stats_for_csv(record):
 
 
 def get_ap_and_pv_csv(data, filename, ap=False, tandem=False):
-
     response = HttpResponse(content_type='text/csv')
     response['Content-Disposition'] = f"attachment; filename={filename}_{datetime.now().strftime('%Y_%m_%d_%H%M%S')}.csv"
 
@@ -490,7 +492,6 @@ def get_ap_and_pv_csv(data, filename, ap=False, tandem=False):
         except:
             posteddate = "None listed"
 
-
         if record["position"]["post"]["differential_rate"] is not None:
             formattedDifferential = record["position"]["post"]["differential_rate"]
         else:
@@ -538,7 +539,6 @@ def get_ap_and_pv_csv(data, filename, ap=False, tandem=False):
 
 
 def get_bids_csv(data, filename, jwt_token):
-
     response = HttpResponse(content_type='text/csv')
     response['Content-Disposition'] = f"attachment; filename={filename}_{datetime.now().strftime('%Y_%m_%d_%H%M%S')}.csv"
 
@@ -583,7 +583,7 @@ def get_bids_csv(data, filename, jwt_token):
         "submitted": "Submitted",
     }
 
-    bid_status_list = [ 
+    bid_status_list = [
         "handshake_needs_registered",
         "submitted",
     ]
@@ -601,7 +601,7 @@ def get_bids_csv(data, filename, jwt_token):
 
             if hs_offered == "Yes" and status in bid_status_list:
                 hs_offered_bid_status = "handshake_with_another_bidder"
-            
+
             hs_status = (pydash.get(record, 'handshake.hs_status_code') or '').replace('_', ' ') or 'N/A'
             row = []
             row.append(pydash.get(bid_status, hs_offered_bid_status) or 'N/A')
@@ -657,6 +657,7 @@ def archive_favorites(ids, request, isPV=False, favoritesLimit=FAVORITES_LIMIT):
                     AvailablePositionFavorite.objects.filter(cp_id__in=outdated_ids).update(archived=True)
                     AvailableFavoriteTandem.objects.filter(cp_id__in=outdated_ids).update(archived=True)
 
+
 # Determine if the bidder has a competing #1 ranked bid on a position within the requester's org or bureau permissions
 def has_competing_rank(jwt, perdet, pk):
     rankOneBids = AvailablePositionRanking.objects.filter(bidder_perdet=perdet, rank=0).exclude(cp_id=pk).values_list(
@@ -665,7 +666,7 @@ def has_competing_rank(jwt, perdet, pk):
     aps = []
     if rankOneBids:
         ids = ','.join(rankOneBids)
-        ap = apservices.get_available_positions({ 'id': ids, 'page': 1, 'limit': len(rankOneBids) or 1 }, jwt)
+        ap = apservices.get_available_positions({'id': ids, 'page': 1, 'limit': len(rankOneBids) or 1}, jwt)
         aps = pydash.map_(ap['results'], 'id')
 
     for y in aps:
@@ -675,6 +676,7 @@ def has_competing_rank(jwt, perdet, pk):
             # don't bother continuing the loop if we've already found one
             return True
     return False
+
 
 def get_bidders_csv(self, pk, data, filename, jwt_token):
     response = HttpResponse(content_type='text/csv')
@@ -735,7 +737,7 @@ def get_bidders_csv(self, pk, data, filename, jwt_token):
     return response
 
 
-def get_secondary_skill(pos = {}):
+def get_secondary_skill(pos={}):
     skillSecondary = f"{pos.get('pos_staff_ptrn_skill_desc', None)} ({pos.get('pos_staff_ptrn_skill_code')})"
     skillSecondaryCode = pos.get("pos_staff_ptrn_skill_code", None)
     if pos.get("pos_skill_code", None) == pos.get("pos_staff_ptrn_skill_code", None):
@@ -767,22 +769,23 @@ HAND_SHAKE_OFFER_DECLINED_PROP = 'handshake_declined'
 HAND_SHAKE_REVOKED_PROP = 'handshake_offer_revoked'
 
 bid_status_order = {
-  DECLINED_PROP: 10,
-  CLOSED_PROP: 20,
-  HAND_SHAKE_DECLINED_PROP: 30,
-  HAND_SHAKE_OFFER_DECLINED_PROP: 40,
-  HAND_SHAKE_REVOKED_PROP: 50,
-  DRAFT_PROP: 60,
-  SUBMITTED_PROP: 70,
-  HAND_SHAKE_OFFERED_PROP: 80,
-  HAND_SHAKE_OFFER_ACCEPTED_PROP: 90,
-  HAND_SHAKE_NEEDS_REGISTER_PROP: 100,
-  HAND_SHAKE_ACCEPTED_PROP: 110,
-  PRE_PANEL_PROP: 120,
-  PANEL_RESCHEDULED_PROP: 130,
-  IN_PANEL_PROP: 140,
-  APPROVED_PROP: 150,
+    DECLINED_PROP: 10,
+    CLOSED_PROP: 20,
+    HAND_SHAKE_DECLINED_PROP: 30,
+    HAND_SHAKE_OFFER_DECLINED_PROP: 40,
+    HAND_SHAKE_REVOKED_PROP: 50,
+    DRAFT_PROP: 60,
+    SUBMITTED_PROP: 70,
+    HAND_SHAKE_OFFERED_PROP: 80,
+    HAND_SHAKE_OFFER_ACCEPTED_PROP: 90,
+    HAND_SHAKE_NEEDS_REGISTER_PROP: 100,
+    HAND_SHAKE_ACCEPTED_PROP: 110,
+    PRE_PANEL_PROP: 120,
+    PANEL_RESCHEDULED_PROP: 130,
+    IN_PANEL_PROP: 140,
+    APPROVED_PROP: 150,
 }
+
 
 def sort_bids(bidlist, ordering_query):
     ordering = sorting_values(ordering_query)
@@ -794,7 +797,7 @@ def sort_bids(bidlist, ordering_query):
             is_asc = pydash.get(ordering, '[1]') == 'asc'
             bids = sorted(bids, key=lambda x: pydash.get(x, order, '') or '', reverse=not is_asc)
         elif ordering_query in ('status', '-status'):
-            bids = pydash.map_(bids, lambda x: { **x, "ordering": bid_status_order[x['status']] })
+            bids = pydash.map_(bids, lambda x: {**x, "ordering": bid_status_order[x['status']]})
             bids = pydash.sort_by(bids, "ordering", reverse=ordering_query[0] == '-')
             bids = pydash.map_(bids, lambda x: pydash.omit(x, 'ordering'))
             bids.reverse()
@@ -802,7 +805,8 @@ def sort_bids(bidlist, ordering_query):
         logger.error(f"{type(e).__name__} at line {e.__traceback__.tb_lineno} of {__file__}: {e}")
         return bidlist
     return bids
-    
+
+
 # known comparators:
 # eq: equals
 # in: in
@@ -825,18 +829,18 @@ def convert_to_fsbid_ql(filters):
     return formattedFilters
 
 
-def categorize_remark(remark = ''):
-    obj = { 'text': remark, 'type': None }
+def categorize_remark(remark=''):
+    obj = {'text': remark, 'type': None}
     if pydash.starts_with(remark, 'Creator') or pydash.starts_with(remark, 'CDO:') or pydash.starts_with(remark, 'Modifier'):
         obj['type'] = 'person'
     return obj
 
 
-def parse_agenda_remarks(remarks = []):
+def parse_agenda_remarks(remarks=[]):
     remarks_values = []
-    if (remarks):
+    if remarks:
         for remark in remarks:
-            if (pydash.get(remark, 'remarkRefData[0].rmrktext') in [None, '']):
+            if pydash.get(remark, 'remarkRefData[0].rmrktext') in [None, '']:
                 if not pydash.get(remark, 'remarkInserts'):
                     continue
                 remark['remarkRefData'][0]['rmrktext'] = pydash.get(remark, 'remarkInserts')[0]['airiinsertiontext']
@@ -852,7 +856,7 @@ def parse_agenda_remarks(remarks = []):
             refRemarkText = pydash.get(remark, 'remarkRefData[0].rmrktext')
             refInsertionsText = pydash.get(remark, 'remarkRefData[0].RemarkInserts')
 
-            if (remarkInsertions):
+            if remarkInsertions:
                 for insertion in remarkInsertions:
                     matchText = pydash.find(refInsertionsText, {'riseqnum': insertion['aiririseqnum']})
                     if (matchText):
@@ -861,6 +865,10 @@ def parse_agenda_remarks(remarks = []):
                         continue
 
             remark['remarkRefData'][0]['rmrktext'] = refRemarkText
+
+            if remark['remarkRefData'][0]['rmrkactiveind'] == 'N':
+                remark['remarkRefData'][0]['rmrktext'] += ' (legacy)'
+
             pydash.unset(remark, 'remarkRefData[0].RemarkInserts')
             remarks_values.append(agendaservices.fsbid_to_talentmap_agenda_remarks(remark['remarkRefData'][0]))
     
@@ -903,7 +911,7 @@ def get_aih_csv(data, filename):
             panelDate = smart_str(maya.parse(pydash.get(record, "panel_date")).datetime().strftime('%m/%d/%Y'))
         except:
             panelDate = "None listed"
-        
+
         try:
             remarks = pydash.map_(pydash.get(record, "remarks", []), 'text')
             remarks = pydash.join(remarks, '; ')
@@ -926,12 +934,14 @@ def get_aih_csv(data, filename):
         writer.writerow(row)
     return response
 
+
 def map_return_template_cols(cols, cols_mapping, data):
     # cols: an array of strs of the TM data names to map and return
     # cols_mapping: dict to map from TM names(key) to WS names(value)
     props_to_map = pydash.pick(cols_mapping, *cols)
     mapped_tuples = map(lambda x: (x[0], pydash.get(data, x[1]).strip() if type(pydash.get(data, x[1])) == str else pydash.get(data, x[1])), props_to_map.items())
     return dict(mapped_tuples)
+
 
 # optimized map_return_template_cols
 def map_fsbid_template_to_tm(data, mapping):
@@ -951,6 +961,7 @@ def if_str_upper(x):
         return x.upper()
 
     return x
+
 
 # mapping = {
 #   'default': 'None', <-default value for all values (required)
@@ -972,7 +983,7 @@ def csv_fsbid_template_to_tm(data, mapping):
     row = []
 
     for x in mapping['wskeys'].keys():
-        default =  mapping['wskeys'][x]['default'] if 'default' in mapping['wskeys'][x] else mapping['default']
+        default = mapping['wskeys'][x]['default'] if 'default' in mapping['wskeys'][x] else mapping['default']
 
         if 'transformFn' in mapping['wskeys'][x]:
             mapped = mapping['wskeys'][x]['transformFn'](pydash.get(data, x)) or default
@@ -984,6 +995,7 @@ def csv_fsbid_template_to_tm(data, mapping):
             row.append(smart_str(pydash.get(data, x) or default))
 
     return row
+
 
 def process_dates_csv(date):
     if (date):
@@ -1021,4 +1033,3 @@ def panel_process_dates_csv(dates):
                 columnOrdering.update({date['mdtcode']: 'None Listed'})
 
     return list(columnOrdering.values())
-

--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -836,7 +836,7 @@ def categorize_remark(remark=''):
     return obj
 
 
-def parse_agenda_remarks(remarks = []):
+def parse_agenda_remarks(remarks=[]):
     remarks_values = []
     if remarks:
         for remark in remarks:


### PR DESCRIPTION
Legacy Remarks

Show it and if editable it can be removed, but you can’t re-add it. If you can edit it then ` (legacy)` should let you know that you should remove/replace it. 
Glossary already filters out the legacy ones, so we should be good with preventing the adding of any new legacy ones. 