### PR TITLE
Vice fix

### DIFF
--- a/talentmap_api/fsbid/services/agenda.py
+++ b/talentmap_api/fsbid/services/agenda.py
@@ -910,7 +910,7 @@ def get_vice_data(pos_seq_nums, jwt_token):
 def vice_query_mapping(pos_seq_nums):
     pos_seq_nums_string = ','.join(map(str, list(set(pos_seq_nums)))) 
     filters = services.convert_to_fsbid_ql([
-        {'col': 'pos_seq_num', "com": "IN", 'val': pos_seq_nums_string},
+        {'col': 'pos_seq_num', 'com': 'IN', 'val': pos_seq_nums_string},
     ])
     values = {
         "rp.filter": filters,

--- a/talentmap_api/fsbid/services/agenda.py
+++ b/talentmap_api/fsbid/services/agenda.py
@@ -909,7 +909,7 @@ def get_vice_data(pos_seq_nums, jwt_token):
     return vice_lookup
 
 def vice_query_mapping(pos_seq_nums):
-    pos_seq_nums_string = ','.join(map(str, list(set(pos_seq_nums)))) 
+    pos_seq_nums_string = ','.join(map(lambda x: str(x), list(set(pos_seq_nums))))
     filters = services.convert_to_fsbid_ql([
         {'col': 'pos_seq_num', 'com': 'IN', 'val': pos_seq_nums_string},
     ])

--- a/talentmap_api/fsbid/services/agenda.py
+++ b/talentmap_api/fsbid/services/agenda.py
@@ -895,15 +895,16 @@ def get_vice_data(pos_seq_nums, jwt_token):
 
     vice_lookup = {}    
     for vice in vice_data or []:
-        pos_seq = vice["pos_seq_num"]
-        # check for multiple incumbents in same postion
-        if pos_seq in vice_lookup:
-            vice_lookup[pos_seq] = {
-                "pos_seq_num": pos_seq,
-                "emp_full_name": "Multiple Incumbents"
-            }
-        else:
-            vice_lookup[pos_seq] = vice
+        if "pos_seq_num" in vice:
+          pos_seq = vice["pos_seq_num"]
+          # check for multiple incumbents in same postion
+          if pos_seq in vice_lookup:
+              vice_lookup[pos_seq] = {
+                  "pos_seq_num": pos_seq,
+                  "emp_full_name": "Multiple Incumbents"
+              }
+          else:
+              vice_lookup[pos_seq] = vice
 
     return vice_lookup
 

--- a/talentmap_api/fsbid/services/agenda.py
+++ b/talentmap_api/fsbid/services/agenda.py
@@ -910,7 +910,7 @@ def get_vice_data(pos_seq_nums, jwt_token):
 def vice_query_mapping(pos_seq_nums):
     pos_seq_nums_string = ','.join(map(str, list(set(pos_seq_nums)))) 
     filters = services.convert_to_fsbid_ql([
-        {'col': 'pos_seq_num', 'val': pos_seq_nums_string},
+        {'col': 'pos_seq_num', "com": "IN", 'val': pos_seq_nums_string},
     ])
     values = {
         "rp.filter": filters,


### PR DESCRIPTION
the call to the vice API is throwing this error in dev
<img width="596" alt="image" src="https://github.com/MetaPhase-Consulting/State-TalentMAP-API/assets/12723877/6d8f0f0d-131b-42de-a6d8-7154db932e85">

which is the same error you get in swagger when trying `pos_seq_num|EQ|39745,43138|` instead of `pos_seq_num|IN|39745,43138|`

this code should both fix the issue and have it fail gracefully, if the calls fails... though, it wasn't quite working when dev turned off - will tinker with it first thing in the AM 