### PR TITLE
swapping reading and speaking in representation field

### DIFF
--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -88,7 +88,7 @@ def parseLanguage(lang):
             language["language"] = match.group(1).strip()
             language["reading_proficiency"] = match.group(3).replace(' ', '')
             language["spoken_proficiency"] = match.group(4).replace(' ', '')
-            language["representation"] = f"{match.group(1).strip()} {match.group(2).replace(' ', '')} {match.group(3).replace(' ', '')}/{match.group(4).replace(' ', '')}"
+            language["representation"] = f"{match.group(1).strip()} {match.group(2).replace(' ', '')} {match.group(4).replace(' ', '')}/{match.group(3).replace(' ', '')}"
             return language
 
 


### PR DESCRIPTION
The fix was just swapping the order in which the representation field is constructed in the BE (parseLanguage() in common.py). Won't really be able to test it locally, but in DEV1 we will see some languages swap. For testing purposes, you can print out the speaking and reading scores in `common.py` `parseLanguage()` and then confirm that the `representation` field has combined them in the correct order (Speaking: X Reading: Y)

Dual Merge: 
- [FE PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2783)

[Ticket](https://metaphase.atlassian.net/browse/TM-5196)
