### PR TITLE
TM-5479, none listed vs not applicable

### DIFF
--- a/talentmap_api/fsbid/services/agenda.py
+++ b/talentmap_api/fsbid/services/agenda.py
@@ -633,11 +633,10 @@ def fsbid_legs_to_talentmap_legs(data):
     country_state = pydash.get(data, 'ailcountrystatetext') or ''
     location = f"{city}{', ' if (city and country_state) else ''}{country_state}"
     lat_code = pydash.get(data, 'aillatcode')
-    tod_ind = 'INDEFINITE'
-    ted_na = 'N/A'
     skills_data = services.get_skills(pydash.get(data, 'agendaLegPosition[0]', {}))
     eta_date = data.get("ailetadate", None)
     ted_date = data.get("ailetdtedsepdate", None)
+    not_applicable = '-'
 
     res = {
         "id": pydash.get(data, "ailaiseqnum", None),
@@ -651,7 +650,7 @@ def fsbid_legs_to_talentmap_legs(data):
         "pos_num": pydash.get(data, "agendaLegPosition[0].posnumtext", None),
         "org": pydash.get(data, "agendaLegPosition[0].posorgshortdesc", None),
         "eta": pydash.get(data, "ailetadate", None),
-        "ted": ted_na if tod_long_desc == tod_ind else pydash.get(data, "ailetdtedsepdate", None),
+        "ted": not_applicable if tod_long_desc == 'INDEFINITE' else pydash.get(data, "ailetdtedsepdate", None),
         "tod": tod_code,
         "tod_is_dropdown": tod_is_dropdown,
         "tod_months": tod_months if is_other_tod else None, # only a custom/other TOD should have months
@@ -680,15 +679,16 @@ def fsbid_legs_to_talentmap_legs(data):
         res['is_separation'] = True
         res['sort_date'] = data.get("ailetdtedsepdate", None)  # Separations are sorted by TED
         res['pos_title'] = pydash.get(data, 'latdesctext')
-        res['pos_num'] = None
-        res['eta'] = None
-        res['tod'] = None
-        res['tod_short_desc'] = None
+        res['pos_num'] = not_applicable
+        res['eta'] = not_applicable
+        res['tod'] = not_applicable
+        res['tod_short_desc'] = not_applicable
         res['tod_months'] = None
-        res['tod_long_desc'] = None
-        res['grade'] = None
-        res['languages'] = None
+        res['tod_long_desc'] = not_applicable
+        res['grade'] = not_applicable
+        res['languages'] = not_applicable
         res['org'] = location
+        res['custom_skills_description'] = not_applicable
         res['separation_location'] = {
                 "city": city,
                 "country": country_state,
@@ -729,9 +729,8 @@ def fsbid_aia_to_talentmap_aia(data):
     tod_short_desc = pydash.get(data, "todshortdesc")
     tod_long_desc = pydash.get(data, "toddesctext")
     is_other_tod = True if (tod_code == 'X') and (tod_other_text) else False
-    tod_ind = 'INDEFINITE'
-    ted_na = 'N/A'
     skills_data = services.get_skills(pydash.get(data, 'position[0]', {}))
+    not_applicable = '-'
 
     return {
         "id": pydash.get(data, "asgdasgseqnum", None),
@@ -742,15 +741,15 @@ def fsbid_aia_to_talentmap_aia(data):
         "pos_num": pydash.get(data, "position[0].posnumtext", None),
         "org": pydash.get(data, "position[0].posorgshortdesc", None),
         "eta": pydash.get(data, "asgdetadate", None),
-        "ted": ted_na if tod_long_desc == tod_ind else pydash.get(data, "asgdetdteddate", None),
+        "ted": not_applicable if tod_long_desc == 'INDEFINITE' else pydash.get(data, "asgdetdteddate", None),
         "tod": tod_code,
         "tod_months": tod_months if is_other_tod else None, # only custom/other TOD should have months and other_text
         "tod_short_desc": tod_other_text if is_other_tod else tod_short_desc,
         "tod_long_desc": tod_other_text if is_other_tod else tod_long_desc,
         "grade": pydash.get(data, "position[0].posgradecode", None),
         "languages": services.parseLanguagesToArr(pydash.get(data, "position[0]", None)),
-        "travel": "-",
-        "action": "-",
+        "travel": not_applicable,
+        "action": not_applicable,
         "is_separation": False,
         "pay_plan": pydash.get(data, "position[0].pospayplancode", None),
         "pay_plan_desc": pydash.get(data, "position[0].pospayplandesc", None),


### PR DESCRIPTION
OK - this was kind of tricky, and took me a little while to wrap my head around & think through. 

Decided to pass the "-" for not applicable fields from the backend, so the read-only fields of the frontend won't need any logic to decide how to render anything. 

The other option was to pass None from the API and then have the frontend parse and decide what to render - but i think that could make that code a little more messy than it needs to be.  Would just have to add the same logic to `AgendaItemLegsFormReadOnly` & `AgendaItemLegs` that's in `AgendaLeg` where the editing happens.  

Dual Merge: 
- [FE PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2846)

[Ticket](https://metaphase.atlassian.net/browse/TM-5479)
