### PR TITLE
[TM-5389] Projected Vacancy Integration (Edit)

### DIFF
--- a/talentmap_api/common/common_helpers.py
+++ b/talentmap_api/common/common_helpers.py
@@ -130,8 +130,17 @@ def service_response(data, objStr, mapping=None):
     '''
     if data is None:
         logger.error(f"Fsbid call for {objStr} failed with no return data.")
+
+    return_attribute = 'O_RETURN_CODE'
+    error_attribute = 'QRY_ERROR_DATA'
+
+    for key, value in data.items():
+        if ('RETURN_CODE' in key):
+            return_attribute = key
+        if ('ERROR_DATA' in key):
+            error_attribute = key
     
-    return_code = data['O_RETURN_CODE']
+    return_code = data[return_attribute]
 
     if (return_code):
         if (return_code is -1):
@@ -139,7 +148,7 @@ def service_response(data, objStr, mapping=None):
             return {
                 'return_code': return_code,
                 'fsbid_reference': objStr,
-                'error_message': data.get('QRY_ERROR_DATA')[0].get('MSG_TXT')
+                'error_message': data[error_attribute][0].get('MSG_TXT')
             }
         if (return_code is -2):
             logger.error(f"Fsbid call for {objStr} failed with error data returned.")

--- a/talentmap_api/fsbid/services/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/services/admin_projected_vacancies.py
@@ -85,17 +85,17 @@ def admin_projected_vacancy_filter_res_mapping(response):
         }
     return service_response(response, 'Projected Vacancy Filters', filters_map)
 
-# ======================== Get PV Dropdowns ========================
+# ======================== Get PV Language Offset Options ========================
 
-def get_admin_projected_vacancy_language_offsets(jwt_token):
+def get_admin_projected_vacancy_lang_offset_options(jwt_token):
     '''
-    Gets Language Offsets for Admin Projected Vacancies
+    Gets Language Offset Options for Admin Projected Vacancies
     '''
     args = {
         "proc_name": "PRC_LST_POS_PLO_CRITERIA",
         "package_name": "PKG_WEBAPI_WRAP_SPRINT98",
         "request_mapping_function": admin_projected_vacancy_filter_req_mapping,
-        "response_mapping_function": admin_projected_vacancy_language_offsets_res_mapping,
+        "response_mapping_function": admin_projected_vacancy_lang_offset_options_res_mapping,
         "jwt_token": jwt_token,
         "request_body": {},
     }
@@ -103,7 +103,7 @@ def get_admin_projected_vacancy_language_offsets(jwt_token):
         **args
     )
 
-def admin_projected_vacancy_language_offsets_res_mapping(response):
+def admin_projected_vacancy_lang_offset_options_res_mapping(response):
     def language_offset_map(x):
         return {
             'code': x.get("LOT_SEQ_NUM"),

--- a/talentmap_api/fsbid/services/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/services/admin_projected_vacancies.py
@@ -132,8 +132,31 @@ def get_admin_projected_vacancies(query, jwt_token):
 
 def admin_projected_vacancy_request_mapping(request):
     mapped_request = {
-        "PV_API_VERSION_I": "",
-        "PV_AD_ID_I": "",
+        'PV_API_VERSION_I': '',
+        'PV_AD_ID_I': '',
+        'PV_SUBTRAN_I': '',
+        'PJSON_FVS_TAB_I': { 'Data': [] },
+        'PJSON_CUST_TP_TAB_I': { 'Data': [] },
+        'PXML_POSITION_I': '''
+            <XMLSearchCriterias>
+                <SearchList>
+                    <Value>30008009</Value>
+                    <Value>30008008</Value>
+                </SearchList>
+            </XMLSearchCriterias>
+        ''',
+        'PJSON_JC_DD_TAB_I': { 'Data': [] },
+        'PXML_OVERSEAS_I': '''
+            <XMLSearchCriterias>
+                <SearchList>
+                    <Value>O</Value>
+                    <Value>D</Value>
+                </SearchList>
+            </XMLSearchCriterias>
+        ''',
+        'PQRY_FV_ADMIN_O': '',
+        'PV_RETURN_CODE_O': '',
+        'PQRY_ERROR_DATA_O': '',
     }
     if request.get('bureaus'):
         mapped_request['PJSON_BUREAU_TAB_I'] = services.format_request_data_to_string(request.get('bureaus'), 'BUREAU_ORG_CODE')
@@ -270,3 +293,79 @@ def edit_admin_projected_vacancy_request_mapping(request):
 
 def edit_admin_projected_vacancy_response_mapping(data):
     return service_response(data, 'Projected Vacancy Edit')
+
+# ======================== Edit PV Language Offsets ========================
+
+def edit_admin_projected_vacancy_lang_offsets(data, jwt_token):
+    '''
+    Edit Admin Projected Vacancy Language Offsets
+    '''
+    args = {
+        "proc_name": 'PRC_IUD_POSITION_PLO',
+        "package_name": 'PKG_WEBAPI_WRAP_SPRINT98',
+        "request_mapping_function": edit_admin_projected_vacancy_lang_offsets_request_mapping,
+        "response_mapping_function": edit_admin_projected_vacancy_lang_offsets_response_mapping,
+        "jwt_token": jwt_token,
+        "request_body": data,
+    }
+    return services.send_post_back_office(
+        **args
+    )
+
+def edit_admin_projected_vacancy_lang_offsets_request_mapping(request):
+    return {
+        'PV_API_VERSION_I': '',
+        'PV_AD_ID_I': '',
+        'PX_LANGOS_I': f'''
+            <ROWSET>
+                <ROW>
+                    <POS_SEQ_NUM>{request.get('positon_seq_num')}</POS_SEQ_NUM>
+                    <LOT_SEQ_NUM>{request.get('language_offset_summer')}</LOT_SEQ_NUM>
+                </ROW>
+            </ROWSET>
+        ''',
+        'PX_LANGOW_I': f'''
+            <ROWSET>
+                <ROW>
+                    <POS_SEQ_NUM>{request.get('positon_seq_num')}</POS_SEQ_NUM>
+                    <LOT_SEQ_NUM>{request.get('language_offset_winter')}</LOT_SEQ_NUM>
+                </ROW>
+            </ROWSET>
+        ''',
+        'PV_RETURN_CODE_O': '',
+        'PQRY_ERROR_DATA_O': ''
+    }
+
+def edit_admin_projected_vacancy_lang_offsets_response_mapping(data):
+    return service_response(data, 'Projected Vacancy Edit Language Offsets')
+
+# ======================== Edit PV Capsule Description ========================
+
+def edit_admin_projected_vacancy_capsule_desc(data, jwt_token):
+    '''
+    Edit Admin Projected Vacancy Capsule Description
+    '''
+    args = {
+        "proc_name": 'act_modCapsulePos',
+        "package_name": 'PKG_WEBAPI_WRAP_SPRINT98',
+        "request_mapping_function": edit_admin_projected_vacancy_capsule_desc_request_mapping,
+        "response_mapping_function": edit_admin_projected_vacancy_capsule_desc_response_mapping,
+        "jwt_token": jwt_token,
+        "request_body": data,
+    }
+    return services.send_post_back_office(
+        **args
+    )
+
+def edit_admin_projected_vacancy_capsule_desc_request_mapping(request):
+    return {
+        'PV_API_VERSION_I': '',
+        'PV_AD_ID_I': '',
+        'I_POS_SEQ_NUM': request.get('positon_seq_num'),
+        'I_PPOS_CAPSULE_DESCR_TXT': request.get('capsule_description'),
+        'I_PPOS_LAST_UPDT_USER_ID': request.get('updater_id'),
+        'I_PPOS_LAST_UPDT_TMSMP_DT': request.get('updated_date'),
+    }
+
+def edit_admin_projected_vacancy_capsule_desc_response_mapping(data):
+    return service_response(data, 'Projected Vacancy Edit Capsule Description')

--- a/talentmap_api/fsbid/services/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/services/admin_projected_vacancies.py
@@ -413,11 +413,12 @@ def get_admin_projected_vacancy_metadata_req_mapping(request):
 
 def get_admin_projected_vacancy_metadata_res_mapping(response):
     def metadata_mapping(x):
+        admin_data = x.get('PQRY_FV_ADMIN_O')[0]
         return {
-            'creator_id': x.get('FV_CREATE_ID'),
-            'created_date': x.get('FV_CREATE_DATE'),
-            'updater_id': x.get('FV_UPDATE_ID'),
-            'updated_date': x.get('FV_UPDATE_DATE'),
+            'creator_id': admin_data.get('FV_CREATE_ID'),
+            'created_date': admin_data.get('FV_CREATE_DATE'),
+            'updater_id': admin_data.get('FV_UPDATE_ID'),
+            'updated_date': admin_data.get('FV_UPDATE_DATE'),
         }
     return service_response(response, 'Projected Vacancy Metadata', metadata_mapping)
 
@@ -467,8 +468,9 @@ def get_admin_projected_vacancy_lang_offsets_req_mapping(request):
 
 def get_admin_projected_vacancy_lang_offsets_res_mapping(response):
     def lang_offset_mapping(x):
+        admin_data = x.get('PQRY_FVPL_ADMIN_O')[0]
         return {
-            "language_offset_summer": x.get("LANG_OFFSET_SUMMER"),
-            "language_offset_winter": x.get("LANG_OFFSET_WINTER"),
+            'language_offset_summer': admin_data.get('LANG_OFFSET_SUMMER'),
+            'language_offset_winter': admin_data.get('LANG_OFFSET_WINTER'),
         }
     return service_response(response, 'Projected Vacancy Language Offsets', lang_offset_mapping)

--- a/talentmap_api/fsbid/services/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/services/admin_projected_vacancies.py
@@ -104,7 +104,7 @@ def get_admin_projected_vacancy_language_offsets(jwt_token):
     )
 
 def admin_projected_vacancy_language_offsets_res_mapping(response):
-    def language_offsets_map(x):
+    def language_offset_map(x):
         return {
             'code': x.get("LOT_SEQ_NUM"),
             'description': x.get("LO_DESCR_TEXT"),
@@ -259,8 +259,8 @@ def edit_admin_projected_vacancy(data, jwt_token):
     args = {
         "proc_name": 'PRC_IUD_FUTURE_VACANCY',
         "package_name": 'PKG_WEBAPI_WRAP_SPRINT98',
-        "request_mapping_function": edit_admin_projected_vacancy_request_mapping,
-        "response_mapping_function": edit_admin_projected_vacancy_response_mapping,
+        "request_mapping_function": edit_admin_projected_vacancy_req_mapping,
+        "response_mapping_function": edit_admin_projected_vacancy_res_mapping,
         "jwt_token": jwt_token,
         "request_body": data,
     }
@@ -268,7 +268,7 @@ def edit_admin_projected_vacancy(data, jwt_token):
         **args
     )
 
-def edit_admin_projected_vacancy_request_mapping(request):
+def edit_admin_projected_vacancy_req_mapping(request):
     pvData = []
     for pv in request:
         pvData.append({
@@ -300,7 +300,7 @@ def edit_admin_projected_vacancy_request_mapping(request):
         }
     }
 
-def edit_admin_projected_vacancy_response_mapping(data):
+def edit_admin_projected_vacancy_res_mapping(data):
     return service_response(data, 'Projected Vacancy Edit')
 
 # ======================== Edit PV Language Offsets ========================
@@ -312,8 +312,8 @@ def edit_admin_projected_vacancy_lang_offsets(data, jwt_token):
     args = {
         "proc_name": 'PRC_IUD_POSITION_PLO',
         "package_name": 'PKG_WEBAPI_WRAP_SPRINT98',
-        "request_mapping_function": edit_admin_projected_vacancy_lang_offsets_request_mapping,
-        "response_mapping_function": edit_admin_projected_vacancy_lang_offsets_response_mapping,
+        "request_mapping_function": edit_admin_projected_vacancy_lang_offsets_req_mapping,
+        "response_mapping_function": edit_admin_projected_vacancy_lang_offsets_res_mapping,
         "jwt_token": jwt_token,
         "request_body": data,
     }
@@ -321,7 +321,7 @@ def edit_admin_projected_vacancy_lang_offsets(data, jwt_token):
         **args
     )
 
-def edit_admin_projected_vacancy_lang_offsets_request_mapping(request):
+def edit_admin_projected_vacancy_lang_offsets_req_mapping(request):
     return {
         'PV_API_VERSION_I': '',
         'PV_AD_ID_I': '',
@@ -345,7 +345,7 @@ def edit_admin_projected_vacancy_lang_offsets_request_mapping(request):
         'PQRY_ERROR_DATA_O': ''
     }
 
-def edit_admin_projected_vacancy_lang_offsets_response_mapping(data):
+def edit_admin_projected_vacancy_lang_offsets_res_mapping(data):
     return service_response(data, 'Projected Vacancy Edit Language Offsets')
 
 # ======================== Edit PV Capsule Description ========================
@@ -357,8 +357,8 @@ def edit_admin_projected_vacancy_capsule_desc(data, jwt_token):
     args = {
         "proc_name": 'act_modCapsulePos',
         "package_name": 'PKG_WEBAPI_WRAP_SPRINT98',
-        "request_mapping_function": edit_admin_projected_vacancy_capsule_desc_request_mapping,
-        "response_mapping_function": edit_admin_projected_vacancy_capsule_desc_response_mapping,
+        "request_mapping_function": edit_admin_projected_vacancy_capsule_desc_req_mapping,
+        "response_mapping_function": edit_admin_projected_vacancy_capsule_desc_res_mapping,
         "jwt_token": jwt_token,
         "request_body": data,
     }
@@ -366,7 +366,7 @@ def edit_admin_projected_vacancy_capsule_desc(data, jwt_token):
         **args
     )
 
-def edit_admin_projected_vacancy_capsule_desc_request_mapping(request):
+def edit_admin_projected_vacancy_capsule_desc_req_mapping(request):
     return {
         'PV_API_VERSION_I': '',
         'PV_AD_ID_I': '',
@@ -376,7 +376,7 @@ def edit_admin_projected_vacancy_capsule_desc_request_mapping(request):
         'I_PPOS_LAST_UPDT_TMSMP_DT': request.get('updated_date'),
     }
 
-def edit_admin_projected_vacancy_capsule_desc_response_mapping(data):
+def edit_admin_projected_vacancy_capsule_desc_res_mapping(data):
     return service_response(data, 'Projected Vacancy Edit Capsule Description')
 
 # ======================== Get PV Metadata ========================
@@ -388,8 +388,8 @@ def get_admin_projected_vacancy_metadata(data, jwt_token):
     args = {
         "proc_name": 'PRC_S_FUTURE_VACANCY',
         "package_name": 'PKG_WEBAPI_WRAP_SPRINT98',
-        "request_mapping_function": get_admin_projected_vacancy_metadata_request_mapping,
-        "response_mapping_function": get_admin_projected_vacancy_metadata_response_mapping,
+        "request_mapping_function": get_admin_projected_vacancy_metadata_req_mapping,
+        "response_mapping_function": get_admin_projected_vacancy_metadata_res_mapping,
         "jwt_token": jwt_token,
         "request_body": data,
     }
@@ -397,7 +397,7 @@ def get_admin_projected_vacancy_metadata(data, jwt_token):
         **args
     )
 
-def get_admin_projected_vacancy_metadata_request_mapping(request):
+def get_admin_projected_vacancy_metadata_req_mapping(request):
     return {
         'PV_API_VERSION_I': '',
         'PV_AD_ID_I': '',
@@ -411,7 +411,7 @@ def get_admin_projected_vacancy_metadata_request_mapping(request):
         'PQRY_ERROR_DATA_O': '',
     }
 
-def get_admin_projected_vacancy_metadata_response_mapping(response):
+def get_admin_projected_vacancy_metadata_res_mapping(response):
     def metadata_mapping(x):
         return {
             'creator_id': x.get('FV_CREATE_ID'),
@@ -430,8 +430,8 @@ def get_admin_projected_vacancy_lang_offsets(data, jwt_token):
     args = {
         "proc_name": 'prc_lst_pos_lang_results',
         "package_name": 'PKG_WEBAPI_WRAP_SPRINT98',
-        "request_mapping_function": get_admin_projected_vacancy_lang_offsets_request_mapping,
-        "response_mapping_function": get_admin_projected_vacancy_lang_offsets_response_mapping,
+        "request_mapping_function": get_admin_projected_vacancy_lang_offsets_req_mapping,
+        "response_mapping_function": get_admin_projected_vacancy_lang_offsets_res_mapping,
         "jwt_token": jwt_token,
         "request_body": data,
     }
@@ -439,7 +439,7 @@ def get_admin_projected_vacancy_lang_offsets(data, jwt_token):
         **args
     )
 
-def get_admin_projected_vacancy_lang_offsets_request_mapping(request):
+def get_admin_projected_vacancy_lang_offsets_req_mapping(request):
     return {
         'PV_API_VERSION_I': '',
         'PV_AD_ID_I': '',
@@ -465,7 +465,7 @@ def get_admin_projected_vacancy_lang_offsets_request_mapping(request):
         'PQRY_ERROR_DATA_O': '',
     }
 
-def get_admin_projected_vacancy_lang_offsets_response_mapping(response):
+def get_admin_projected_vacancy_lang_offsets_res_mapping(response):
     def lang_offset_mapping(x):
         return {
             "language_offset_summer": x.get("LANG_OFFSET_SUMMER"),

--- a/talentmap_api/fsbid/services/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/services/admin_projected_vacancies.py
@@ -187,7 +187,7 @@ def admin_projected_vacancy_res_mapping(response):
             "organization_code": x.get("ORG_CODE"),
             "organization_short_description": x.get("ORG_SHORT_DESC"),
             "organization_description": x.get("ORG_LONG_DESC"),
-            "positon_seq_num": x.get("POS_SEQ_NUM"),
+            "position_seq_num": x.get("POS_SEQ_NUM"),
             "position_title": x.get("POS_TITLE_DESC"),
             "position_number": x.get("POS_NUM_TEXT"),
             "position_pay_plan_code": x.get("POS_PAY_PLAN_CODE"),
@@ -274,7 +274,7 @@ def edit_admin_projected_vacancy_req_mapping(request):
         pvData.append({
             'FV_SEQ_NUM': pv.get('future_vacancy_seq_num'),
             'FV_SEQ_NUM_REF': pv.get('future_vacancy_seq_num_ref'),
-            'POS_SEQ_NUM': pv.get('positon_seq_num'),
+            'POS_SEQ_NUM': pv.get('position_seq_num'),
             'BSN_ID': pv.get('bid_season_code'),
             'ASG_SEQ_NUM_EF': pv.get('assignment_seq_num_effective'),
             'ASG_SEQ_NUM': pv.get('assignment_seq_num'),
@@ -328,7 +328,7 @@ def edit_admin_projected_vacancy_lang_offsets_req_mapping(request):
         'PX_LANGOS_I': f'''
             <ROWSET>
                 <ROW>
-                    <POS_SEQ_NUM>{request.get('positon_seq_num')}</POS_SEQ_NUM>
+                    <POS_SEQ_NUM>{request.get('position_seq_num')}</POS_SEQ_NUM>
                     <LOT_SEQ_NUM>{request.get('language_offset_summer')}</LOT_SEQ_NUM>
                 </ROW>
             </ROWSET>
@@ -336,7 +336,7 @@ def edit_admin_projected_vacancy_lang_offsets_req_mapping(request):
         'PX_LANGOW_I': f'''
             <ROWSET>
                 <ROW>
-                    <POS_SEQ_NUM>{request.get('positon_seq_num')}</POS_SEQ_NUM>
+                    <POS_SEQ_NUM>{request.get('position_seq_num')}</POS_SEQ_NUM>
                     <LOT_SEQ_NUM>{request.get('language_offset_winter')}</LOT_SEQ_NUM>
                 </ROW>
             </ROWSET>
@@ -370,7 +370,7 @@ def edit_admin_projected_vacancy_capsule_desc_req_mapping(request):
     return {
         'PV_API_VERSION_I': '',
         'PV_AD_ID_I': '',
-        'I_POS_SEQ_NUM': request.get('positon_seq_num'),
+        'I_POS_SEQ_NUM': request.get('position_seq_num'),
         'I_PPOS_CAPSULE_DESCR_TXT': request.get('capsule_description'),
         'I_PPOS_LAST_UPDT_USER_ID': request.get('updater_id'),
         'I_PPOS_LAST_UPDT_TMSMP_DT': request.get('updated_date'),

--- a/talentmap_api/fsbid/services/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/services/admin_projected_vacancies.py
@@ -1,6 +1,7 @@
 import logging
 import requests  # pylint: disable=unused-import
 from talentmap_api.fsbid.services import common as services
+from talentmap_api.common.common_helpers import service_response
 
 
 logger = logging.getLogger(__name__)
@@ -219,3 +220,53 @@ def admin_projected_vacancy_response_mapping(response):
             "cycle_position_id": x.get("CP_ID"),
         }
     return list(map(projected_vacancy_mapping, response.get("PQRY_FV_ADMIN_O")))
+
+# ======================== Edit PV ========================
+
+def edit_admin_projected_vacancy(data, jwt_token):
+    '''
+    Edit Admin Projected Vacancy
+    '''
+    args = {
+        "proc_name": 'PRC_IUD_FUTURE_VACANCY',
+        "package_name": 'PKG_WEBAPI_WRAP_SPRINT98',
+        "request_mapping_function": edit_admin_projected_vacancy_request_mapping,
+        "response_mapping_function": edit_admin_projected_vacancy_response_mapping,
+        "jwt_token": jwt_token,
+        "request_body": data,
+    }
+    return services.send_post_back_office(
+        **args
+    )
+
+def edit_admin_projected_vacancy_request_mapping(request):
+    return {
+        'PV_API_VERSION_I': '',
+        'PV_AD_ID_I': '',
+        'pv_action_i': 'U',
+        'pjson_fv_i': {
+            'Data': [{
+                'FV_SEQ_NUM': request.get('future_vacancy_seq_num'),
+                'FV_SEQ_NUM_REF': request.get('future_vacancy_seq_num_ref'),
+                'POS_SEQ_NUM': request.get('positon_seq_num'),
+                'BSN_ID': request.get('bid_season_code'),
+                'ASG_SEQ_NUM_EF': request.get('assignment_seq_num_effective'),
+                'ASG_SEQ_NUM': request.get('assignment_seq_num'),
+                'CDT_CD': request.get('cycle_date_type_code'),
+                'FVS_CODE': request.get('future_vacancy_status_code'),
+                'FVO_CODE': request.get('future_vacancy_override_code'),
+                'FV_OVERRIDE_TED_DATE': request.get('future_vacancy_override_tour_end_date'),
+                'FV_SYSTEM_IND': request.get('future_vacancy_system_indicator'),
+                'FV_COMMENT_TXT': request.get('future_vacancy_comment'),
+                'FV_CREATE_ID': request.get('created_date'),
+                'FV_CREATE_DATE': request.get('creator_id'),
+                'FV_UPDATE_ID': request.get('updater_id'),
+                'FV_UPDATE_DATE': request.get('updated_date'),
+                'FV_MC_IND': request.get('future_vacancy_mc_indicator'),
+                'FV_EXCL_IMPORT_IND': request.get('future_vacancy_exclude_import_indicator'),
+            }]
+        }
+    }
+
+def edit_admin_projected_vacancy_response_mapping(data):
+    return service_response(data, 'Projected Vacancy Edit')

--- a/talentmap_api/fsbid/services/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/services/admin_projected_vacancies.py
@@ -73,15 +73,17 @@ def admin_projected_vacancy_filter_response_mapping(response):
             'code': x.get('FVS_CODE'),
             'description': x.get('FVS_DESCR_TXT'),
         }
-    return {
-        'bureauFilters': list(map(bureau_map, response.get('PCUR_BUREAU_TAB_O'))),
-        'organizationFilters': list(map(organization_map, response.get('PCUR_ORG_TAB_O'))),
-        'gradeFilters': list(map(grade_map, response.get('PCUR_GRADE_TAB_O'))),
-        'skillFilters': list(map(skill_map, response.get('PCUR_SKILL_TAB_O'))),
-        'languageFilters': list(map(language_map, response.get('PCUR_LANGUAGE_TAB_O'))),
-        'bidSeasonFilters': list(map(bid_season_map, response.get('PCUR_BSN_TAB_O'))),
-        'futureVacancyStatusFilters': list(map(status_map, response.get('PCUR_FVS_TAB_O'))),
-    }
+    def filters_map(x):
+        return {
+            'bureaus': list(map(bureau_map, x.get('PCUR_BUREAU_TAB_O'))),
+            'organizations': list(map(organization_map, x.get('PCUR_ORG_TAB_O'))),
+            'grades': list(map(grade_map, x.get('PCUR_GRADE_TAB_O'))),
+            'skills': list(map(skill_map, x.get('PCUR_SKILL_TAB_O'))),
+            'languages': list(map(language_map, x.get('PCUR_LANGUAGE_TAB_O'))),
+            'bid_seasons': list(map(bid_season_map, x.get('PCUR_BSN_TAB_O'))),
+            'statuses': list(map(status_map, x.get('PCUR_FVS_TAB_O'))),
+        }
+    return service_response(response, 'Projected Vacancy Filters', filters_map)
 
 # ======================== Get PV Dropdowns ========================
 
@@ -102,15 +104,17 @@ def get_admin_projected_vacancy_language_offsets(jwt_token):
     )
 
 def admin_projected_vacancy_language_offsets_response_mapping(response):
-    def language_offsets_map(x):
+    def language_offset_map(x):
         return {
             'code': x.get("LOT_SEQ_NUM"),
             'description': x.get("LO_DESCR_TEXT"),
         }
-    return {
-        'summerLanguageOffsetFilters': list(map(language_offsets_map, response.get("PQRY_LANG_OFFSET_S_O"))),
-        'winterLanguageOffsetFilters': list(map(language_offsets_map, response.get("PQRY_LANG_OFFSET_W_O"))),
-    }
+    def language_offsets_map(x):
+        return {
+            'summer_language_offsets': list(map(language_offset_map, x.get("PQRY_LANG_OFFSET_S_O"))),
+            'winter_language_offsets': list(map(language_offset_map, x.get("PQRY_LANG_OFFSET_W_O"))),
+        }
+    return service_response(response, 'Projected Vacancy Language Offset Filters', language_offsets_map)
 
 # ======================== Get PV List ========================
 
@@ -242,7 +246,9 @@ def admin_projected_vacancy_response_mapping(response):
             "bid_season_future_vacancy_indicator": x.get("BSN_FUTURE_VACANCY_IND"),
             "cycle_position_id": x.get("CP_ID"),
         }
-    return list(map(projected_vacancy_mapping, response.get("PQRY_FV_ADMIN_O")))
+    def list_pv_mapping(x):
+        return list(map(projected_vacancy_mapping, x.get("PQRY_FV_ADMIN_O")))
+    return service_response(response, 'Projected Vacancy List', list_pv_mapping)
 
 # ======================== Edit PV ========================
 
@@ -263,31 +269,34 @@ def edit_admin_projected_vacancy(data, jwt_token):
     )
 
 def edit_admin_projected_vacancy_request_mapping(request):
+    pvData = []
+    for pv in request:
+        pvData.append({
+            'FV_SEQ_NUM': pv.get('future_vacancy_seq_num'),
+            'FV_SEQ_NUM_REF': pv.get('future_vacancy_seq_num_ref'),
+            'POS_SEQ_NUM': pv.get('positon_seq_num'),
+            'BSN_ID': pv.get('bid_season_code'),
+            'ASG_SEQ_NUM_EF': pv.get('assignment_seq_num_effective'),
+            'ASG_SEQ_NUM': pv.get('assignment_seq_num'),
+            'CDT_CD': pv.get('cycle_date_type_code'),
+            'FVS_CODE': pv.get('future_vacancy_status_code'),
+            'FVO_CODE': pv.get('future_vacancy_override_code'),
+            'FV_OVERRIDE_TED_DATE': pv.get('future_vacancy_override_tour_end_date'),
+            'FV_SYSTEM_IND': pv.get('future_vacancy_system_indicator'),
+            'FV_COMMENT_TXT': pv.get('future_vacancy_comment'),
+            'FV_CREATE_ID': pv.get('creator_id'),
+            'FV_CREATE_DATE': pv.get('created_date'),
+            'FV_UPDATE_ID': pv.get('updater_id'),
+            'FV_UPDATE_DATE': pv.get('updated_date'),
+            'FV_MC_IND': pv.get('future_vacancy_mc_indicator'),
+            'FV_EXCL_IMPORT_IND': pv.get('future_vacancy_exclude_import_indicator'),
+        })
     return {
         'PV_API_VERSION_I': '',
         'PV_AD_ID_I': '',
         'pv_action_i': 'U',
         'pjson_fv_i': {
-            'Data': [{
-                'FV_SEQ_NUM': request.get('future_vacancy_seq_num'),
-                'FV_SEQ_NUM_REF': request.get('future_vacancy_seq_num_ref'),
-                'POS_SEQ_NUM': request.get('positon_seq_num'),
-                'BSN_ID': request.get('bid_season_code'),
-                'ASG_SEQ_NUM_EF': request.get('assignment_seq_num_effective'),
-                'ASG_SEQ_NUM': request.get('assignment_seq_num'),
-                'CDT_CD': request.get('cycle_date_type_code'),
-                'FVS_CODE': request.get('future_vacancy_status_code'),
-                'FVO_CODE': request.get('future_vacancy_override_code'),
-                'FV_OVERRIDE_TED_DATE': request.get('future_vacancy_override_tour_end_date'),
-                'FV_SYSTEM_IND': request.get('future_vacancy_system_indicator'),
-                'FV_COMMENT_TXT': request.get('future_vacancy_comment'),
-                'FV_CREATE_ID': request.get('created_date'),
-                'FV_CREATE_DATE': request.get('creator_id'),
-                'FV_UPDATE_ID': request.get('updater_id'),
-                'FV_UPDATE_DATE': request.get('updated_date'),
-                'FV_MC_IND': request.get('future_vacancy_mc_indicator'),
-                'FV_EXCL_IMPORT_IND': request.get('future_vacancy_exclude_import_indicator'),
-            }]
+            'Data': pvData
         }
     }
 
@@ -369,3 +378,97 @@ def edit_admin_projected_vacancy_capsule_desc_request_mapping(request):
 
 def edit_admin_projected_vacancy_capsule_desc_response_mapping(data):
     return service_response(data, 'Projected Vacancy Edit Capsule Description')
+
+# ======================== Get PV Metadata ========================
+
+def get_admin_projected_vacancy_metadata(data, jwt_token):
+    '''
+    Get Admin Projected Vacancy Metadata
+    '''
+    args = {
+        "proc_name": 'PRC_S_FUTURE_VACANCY',
+        "package_name": 'PKG_WEBAPI_WRAP_SPRINT98',
+        "request_mapping_function": get_admin_projected_vacancy_metadata_request_mapping,
+        "response_mapping_function": get_admin_projected_vacancy_metadata_response_mapping,
+        "jwt_token": jwt_token,
+        "request_body": data,
+    }
+    return services.send_post_back_office(
+        **args
+    )
+
+def get_admin_projected_vacancy_metadata_request_mapping(request):
+    return {
+        'PV_API_VERSION_I': '',
+        'PV_AD_ID_I': '',
+        'PV_FV_SEQ_NUM_I': request.get('future_vacancy_seq_num'),
+        'PQRY_CUST_FV_TAB_O': '',
+        'PQRY_BSN_TAB_O': '',
+        'PQRY_FVS_TAB_O': '',
+        'PQRY_FVO_TAB_O': '',
+        'PQRY_FV_ADMIN_O': '',
+        'PV_RETURN_CODE_O': '',
+        'PQRY_ERROR_DATA_O': '',
+    }
+
+def get_admin_projected_vacancy_metadata_response_mapping(response):
+    def metadata_mapping(x):
+        return {
+            'creator_id': x.get('FV_CREATE_ID'),
+            'created_date': x.get('FV_CREATE_DATE'),
+            'updater_id': x.get('FV_UPDATE_ID'),
+            'updated_date': x.get('FV_UPDATE_DATE'),
+        }
+    return service_response(response, 'Projected Vacancy Metadata', metadata_mapping)
+
+# ======================== Get PV Language Offsets ========================
+
+def get_admin_projected_vacancy_lang_offsets(data, jwt_token):
+    '''
+    Get Admin Projected Vacancy Language Offsets
+    '''
+    args = {
+        "proc_name": 'prc_lst_pos_lang_results',
+        "package_name": 'PKG_WEBAPI_WRAP_SPRINT98',
+        "request_mapping_function": get_admin_projected_vacancy_lang_offsets_request_mapping,
+        "response_mapping_function": get_admin_projected_vacancy_lang_offsets_response_mapping,
+        "jwt_token": jwt_token,
+        "request_body": data,
+    }
+    return services.send_post_back_office(
+        **args
+    )
+
+def get_admin_projected_vacancy_lang_offsets_request_mapping(request):
+    return {
+        'PV_API_VERSION_I': '',
+        'PV_AD_ID_I': '',
+        'PX_BUREAU_I': None,
+        'PX_ORG_I': None,
+        'PX_PAY_PLAN_I': None,
+        'PX_GRADE_I': None,
+        'PX_SKILL_I': None,
+        'PX_LANGUAGE_I': None,
+        'PX_CUST_TP_I': None,
+        'PX_TOD_I': None,
+        'PXML_POSITION_I': f'''
+            <XMLSearchCriterias>
+                <SearchList>
+                    <Value>{request.get('position_seq_num')}</Value>
+                </SearchList>
+            </XMLSearchCriterias>
+        ''',
+        'PX_OVERSEAS_I': None,
+        'PX_COUNTRY_I': None,
+        'PQRY_FV_ADMIN_O': '',
+        'PV_RETURN_CODE_O': '',
+        'PQRY_ERROR_DATA_O': '',
+    }
+
+def get_admin_projected_vacancy_lang_offsets_response_mapping(response):
+    def lang_offset_mapping(x):
+        return {
+            "language_offset_summer": x.get("LANG_OFFSET_SUMMER"),
+            "language_offset_winter": x.get("LANG_OFFSET_WINTER"),
+        }
+    return service_response(response, 'Projected Vacancy Language Offsets', lang_offset_mapping)

--- a/talentmap_api/fsbid/urls/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/urls/admin_projected_vacancies.py
@@ -7,7 +7,7 @@ router = routers.SimpleRouter()
 
 urlpatterns = [
     url(r'^filters/$', views.FSBidAdminProjectedVacancyFiltersView.as_view(), name="admin-projected-vacancies-filters"),
-    url(r'^language_offset_options/$', views.FSBidAdminProjectedVacancyLanguageOffsetOptionsView.as_view(), name="admin-projected-vacancies-lang-offset-options"),
+    url(r'^language_offset_options/$', views.FSBidAdminProjectedVacancyLangOffsetOptionsView.as_view(), name="admin-projected-vacancies-lang-offset-options"),
     url(r'^$', views.FSBidAdminProjectedVacancyListView.as_view(), name="admin-projected-vacancies"),
     url(r'^edit/$', views.FSBidAdminProjectedVacancyActionsView.as_view(), name='admin-projected-vacancies-actions'),
     url(r'^edit_language_offsets/$', views.FSBidAdminProjectedVacancyEditLangOffsetsView.as_view(), name='admin-projected-vacancies-edit-lang-offsets'),

--- a/talentmap_api/fsbid/urls/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/urls/admin_projected_vacancies.py
@@ -10,6 +10,8 @@ urlpatterns = [
     url(r'^language_offsets/$', views.FSBidAdminProjectedVacancyLanguageOffsetsView.as_view(), name="admin-projected-vacancies-lang-offsets"),
     url(r'^$', views.FSBidAdminProjectedVacancyListView.as_view(), name="admin-projected-vacancies"),
     url(r'^edit/$', views.FSBidAdminProjectedVacancyActionsView.as_view(), name='admin-projected-vacancies-actions'),
+    url(r'^edit_language_offsets/$', views.FSBidAdminProjectedVacancyEditLangOffsetsView.as_view(), name='admin-projected-vacancies-edit-language-offsets'),
+    url(r'^edit_capsule_description/$', views.FSBidAdminProjectedVacancyEditCapsuleDescView.as_view(), name='admin-projected-vacancies-edit-capsule-desc'),
 ]
 
 urlpatterns += router.urls

--- a/talentmap_api/fsbid/urls/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/urls/admin_projected_vacancies.py
@@ -9,6 +9,7 @@ urlpatterns = [
     url(r'^filters/$', views.FSBidAdminProjectedVacancyFiltersView.as_view(), name="admin-projected-vacancies-filters"),
     url(r'^language_offsets/$', views.FSBidAdminProjectedVacancyLanguageOffsetsView.as_view(), name="admin-projected-vacancies-lang-offsets"),
     url(r'^$', views.FSBidAdminProjectedVacancyListView.as_view(), name="admin-projected-vacancies"),
+    url(r'^edit/$', views.FSBidAdminProjectedVacancyActionsView.as_view(), name='admin-projected-vacancies-actions'),
 ]
 
 urlpatterns += router.urls

--- a/talentmap_api/fsbid/urls/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/urls/admin_projected_vacancies.py
@@ -10,8 +10,10 @@ urlpatterns = [
     url(r'^language_offsets/$', views.FSBidAdminProjectedVacancyLanguageOffsetsView.as_view(), name="admin-projected-vacancies-lang-offsets"),
     url(r'^$', views.FSBidAdminProjectedVacancyListView.as_view(), name="admin-projected-vacancies"),
     url(r'^edit/$', views.FSBidAdminProjectedVacancyActionsView.as_view(), name='admin-projected-vacancies-actions'),
-    url(r'^edit_language_offsets/$', views.FSBidAdminProjectedVacancyEditLangOffsetsView.as_view(), name='admin-projected-vacancies-edit-language-offsets'),
+    url(r'^edit_language_offsets/$', views.FSBidAdminProjectedVacancyEditLangOffsetsView.as_view(), name='admin-projected-vacancies-edit-lang-offsets'),
     url(r'^edit_capsule_description/$', views.FSBidAdminProjectedVacancyEditCapsuleDescView.as_view(), name='admin-projected-vacancies-edit-capsule-desc'),
+    url(r'^metadata/$', views.FSBidAdminProjectedVacancyMetadataView.as_view(), name='admin-projected-vacancies-metadata'),
+    url(r'^language_offsets/$', views.FSBidAdminProjectedVacancyMetadataView.as_view(), name='admin-projected-vacancies-lang-offsets'),
 ]
 
 urlpatterns += router.urls

--- a/talentmap_api/fsbid/urls/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/urls/admin_projected_vacancies.py
@@ -7,13 +7,13 @@ router = routers.SimpleRouter()
 
 urlpatterns = [
     url(r'^filters/$', views.FSBidAdminProjectedVacancyFiltersView.as_view(), name="admin-projected-vacancies-filters"),
-    url(r'^language_offsets/$', views.FSBidAdminProjectedVacancyLanguageOffsetsView.as_view(), name="admin-projected-vacancies-lang-offsets"),
+    url(r'^language_offset_options/$', views.FSBidAdminProjectedVacancyLanguageOffsetOptionsView.as_view(), name="admin-projected-vacancies-lang-offset-options"),
     url(r'^$', views.FSBidAdminProjectedVacancyListView.as_view(), name="admin-projected-vacancies"),
     url(r'^edit/$', views.FSBidAdminProjectedVacancyActionsView.as_view(), name='admin-projected-vacancies-actions'),
     url(r'^edit_language_offsets/$', views.FSBidAdminProjectedVacancyEditLangOffsetsView.as_view(), name='admin-projected-vacancies-edit-lang-offsets'),
     url(r'^edit_capsule_description/$', views.FSBidAdminProjectedVacancyEditCapsuleDescView.as_view(), name='admin-projected-vacancies-edit-capsule-desc'),
     url(r'^metadata/$', views.FSBidAdminProjectedVacancyMetadataView.as_view(), name='admin-projected-vacancies-metadata'),
-    url(r'^language_offsets/$', views.FSBidAdminProjectedVacancyMetadataView.as_view(), name='admin-projected-vacancies-lang-offsets'),
+    url(r'^language_offsets/$', views.FSBidAdminProjectedVacancyLangOffsetsView.as_view(), name='admin-projected-vacancies-lang-offsets'),
 ]
 
 urlpatterns += router.urls

--- a/talentmap_api/fsbid/views/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/views/admin_projected_vacancies.py
@@ -30,7 +30,7 @@ class FSBidAdminProjectedVacancyFiltersView(APIView):
             return Response(status=status.HTTP_404_NOT_FOUND)
         return Response(result)
 
-class FSBidAdminProjectedVacancyLanguageOffsetOptionsView(APIView):
+class FSBidAdminProjectedVacancyLangOffsetOptionsView(APIView):
 
     # ======================== Get Language Offset Options ========================
 

--- a/talentmap_api/fsbid/views/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/views/admin_projected_vacancies.py
@@ -183,8 +183,7 @@ class FSBidAdminProjectedVacancyMetadataView(APIView):
         result = services.get_admin_projected_vacancy_metadata(request.data, request.META['HTTP_JWT'])
         if result is None:
             return Response(status=status.HTTP_404_NOT_FOUND)
-
-        return Response(status=status.HTTP_204_NO_CONTENT)
+        return Response(result)
 
 class FSBidAdminProjectedVacancyLangOffsetsView(APIView):
     
@@ -205,6 +204,4 @@ class FSBidAdminProjectedVacancyLangOffsetsView(APIView):
         result = services.get_admin_projected_vacancy_lang_offsets(request.data, request.META['HTTP_JWT'])
         if result is None:
             return Response(status=status.HTTP_404_NOT_FOUND)
-
-        return Response(status=status.HTTP_204_NO_CONTENT)
-
+        return Response(result)

--- a/talentmap_api/fsbid/views/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/views/admin_projected_vacancies.py
@@ -30,17 +30,17 @@ class FSBidAdminProjectedVacancyFiltersView(APIView):
             return Response(status=status.HTTP_404_NOT_FOUND)
         return Response(result)
 
-class FSBidAdminProjectedVacancyLanguageOffsetsView(APIView):
+class FSBidAdminProjectedVacancyLanguageOffsetOptionsView(APIView):
 
-    # ======================== Get Language Offsets Dropdowns ========================
+    # ======================== Get Language Offset Options ========================
 
     permission_classes = [IsAuthenticated, Or(isDjangoGroupMember('bureau_user'), isDjangoGroupMember('superuser'), ) ]
 
     def get(self, request):
         '''
-        Gets Language Offsets for Admin Projected Vacancies
+        Gets Language Offset Options for Admin Projected Vacancies
         '''
-        result = services.get_admin_projected_vacancy_language_offsets(request.META['HTTP_JWT'])
+        result = services.get_admin_projected_vacancy_lang_offset_options(request.META['HTTP_JWT'])
         if result is None:
             return Response(status=status.HTTP_404_NOT_FOUND)
         return Response(result)

--- a/talentmap_api/fsbid/views/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/views/admin_projected_vacancies.py
@@ -180,7 +180,7 @@ class FSBidAdminProjectedVacancyMetadataView(APIView):
         '''
         Get Admin Projected Vacancy Metadata
         '''
-        result = services.get_admin_projected_vacancy_metadata(request.data, request.META['HTTP_JWT'])
+        result = services.get_admin_projected_vacancy_metadata(request.query_params, request.META['HTTP_JWT'])
         if result is None:
             return Response(status=status.HTTP_404_NOT_FOUND)
         return Response(result)

--- a/talentmap_api/fsbid/views/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/views/admin_projected_vacancies.py
@@ -72,3 +72,43 @@ class FSBidAdminProjectedVacancyLanguageOffsetsView(APIView):
         if result is None:
             return Response(status=status.HTTP_404_NOT_FOUND)
         return Response(result)
+
+class FSBidAdminProjectedVacancyActionsView(APIView):
+    
+    # ======================== Edit PV ========================
+
+    permission_classes = [IsAuthenticated, isDjangoGroupMember('superuser'), ]
+
+    @swagger_auto_schema(request_body=openapi.Schema(
+        type=openapi.TYPE_OBJECT,
+        properties={
+            'future_vacancy_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description=''),
+            'future_vacancy_seq_num_ref': openapi.Schema(type=openapi.TYPE_STRING, description=''),
+            'positon_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description=''),
+            'bid_season_code': openapi.Schema(type=openapi.TYPE_STRING, description=''),
+            'assignment_seq_num_effective': openapi.Schema(type=openapi.TYPE_STRING, description=''),
+            'assignment_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description=''),
+            'cycle_date_type_code': openapi.Schema(type=openapi.TYPE_STRING, description=''),
+            'future_vacancy_status_code': openapi.Schema(type=openapi.TYPE_STRING, description=''),
+            'future_vacancy_override_code': openapi.Schema(type=openapi.TYPE_STRING, description=''),
+            'future_vacancy_override_tour_end_date': openapi.Schema(type=openapi.TYPE_STRING, description=''),
+            'future_vacancy_system_indicator': openapi.Schema(type=openapi.TYPE_STRING, description=''),
+            'future_vacancy_comment': openapi.Schema(type=openapi.TYPE_STRING, description=''),
+            'created_date': openapi.Schema(type=openapi.TYPE_STRING, description=''),
+            'creator_id': openapi.Schema(type=openapi.TYPE_STRING, description=''),
+            'updater_id': openapi.Schema(type=openapi.TYPE_STRING, description=''),
+            'updated_date': openapi.Schema(type=openapi.TYPE_STRING, description=''),
+            'future_vacancy_mc_indicator': openapi.Schema(type=openapi.TYPE_STRING, description=''),
+            'future_vacancy_exclude_import_indicator': openapi.Schema(type=openapi.TYPE_STRING, description=''),
+        }
+    ))
+
+    def put(self, request):
+        '''
+        Edit Admin Projected Vacancy
+        '''
+        result = services.edit_admin_projected_vacancy(request.data, request.META['HTTP_JWT'])
+        if result is None:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/talentmap_api/fsbid/views/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/views/admin_projected_vacancies.py
@@ -66,7 +66,7 @@ class FSBidAdminProjectedVacancyListView(APIView):
         '''
         Gets List Data for Admin Projected Vacancies 
         '''
-        result = services.get_admin_projected_vacancies(request.data, request.META['HTTP_JWT'])
+        result = services.get_admin_projected_vacancies(request.query_params, request.META['HTTP_JWT'])
         if result is None:
             return Response(status=status.HTTP_404_NOT_FOUND)
         return Response(result)
@@ -80,24 +80,24 @@ class FSBidAdminProjectedVacancyActionsView(APIView):
     @swagger_auto_schema(request_body=openapi.Schema(
         type=openapi.TYPE_OBJECT,
         properties={
-            'future_vacancy_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description=''),
-            'future_vacancy_seq_num_ref': openapi.Schema(type=openapi.TYPE_STRING, description=''),
-            'positon_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description=''),
-            'bid_season_code': openapi.Schema(type=openapi.TYPE_STRING, description=''),
-            'assignment_seq_num_effective': openapi.Schema(type=openapi.TYPE_STRING, description=''),
-            'assignment_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description=''),
-            'cycle_date_type_code': openapi.Schema(type=openapi.TYPE_STRING, description=''),
-            'future_vacancy_status_code': openapi.Schema(type=openapi.TYPE_STRING, description=''),
-            'future_vacancy_override_code': openapi.Schema(type=openapi.TYPE_STRING, description=''),
-            'future_vacancy_override_tour_end_date': openapi.Schema(type=openapi.TYPE_STRING, description=''),
-            'future_vacancy_system_indicator': openapi.Schema(type=openapi.TYPE_STRING, description=''),
-            'future_vacancy_comment': openapi.Schema(type=openapi.TYPE_STRING, description=''),
-            'created_date': openapi.Schema(type=openapi.TYPE_STRING, description=''),
-            'creator_id': openapi.Schema(type=openapi.TYPE_STRING, description=''),
-            'updater_id': openapi.Schema(type=openapi.TYPE_STRING, description=''),
-            'updated_date': openapi.Schema(type=openapi.TYPE_STRING, description=''),
-            'future_vacancy_mc_indicator': openapi.Schema(type=openapi.TYPE_STRING, description=''),
-            'future_vacancy_exclude_import_indicator': openapi.Schema(type=openapi.TYPE_STRING, description=''),
+            'future_vacancy_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Projected Vacancy Seq Num'),
+            'future_vacancy_seq_num_ref': openapi.Schema(type=openapi.TYPE_STRING, description='Projected Vacancy Seq Num Reference'),
+            'positon_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Position Seq Num'),
+            'bid_season_code': openapi.Schema(type=openapi.TYPE_STRING, description='Bid Season Code'),
+            'assignment_seq_num_effective': openapi.Schema(type=openapi.TYPE_STRING, description='Assignment Seq Num Effective'),
+            'assignment_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Assignment Seq Num'),
+            'cycle_date_type_code': openapi.Schema(type=openapi.TYPE_STRING, description='Cycle Date Type Code'),
+            'future_vacancy_status_code': openapi.Schema(type=openapi.TYPE_STRING, description='Status Code'),
+            'future_vacancy_override_code': openapi.Schema(type=openapi.TYPE_STRING, description='Override Code'),
+            'future_vacancy_override_tour_end_date': openapi.Schema(type=openapi.TYPE_STRING, description='Override TED'),
+            'future_vacancy_system_indicator': openapi.Schema(type=openapi.TYPE_STRING, description='System Indicator'),
+            'future_vacancy_comment': openapi.Schema(type=openapi.TYPE_STRING, description='Comment'),
+            'created_date': openapi.Schema(type=openapi.TYPE_STRING, description='Created Date'),
+            'creator_id': openapi.Schema(type=openapi.TYPE_STRING, description='Creator ID'),
+            'updater_id': openapi.Schema(type=openapi.TYPE_STRING, description='Updater ID'),
+            'updated_date': openapi.Schema(type=openapi.TYPE_STRING, description='Updated Date'),
+            'future_vacancy_mc_indicator': openapi.Schema(type=openapi.TYPE_STRING, description='MC Indicator'),
+            'future_vacancy_exclude_import_indicator': openapi.Schema(type=openapi.TYPE_STRING, description='Exclude Import Indicator'),
         }
     ))
 

--- a/talentmap_api/fsbid/views/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/views/admin_projected_vacancies.py
@@ -201,7 +201,7 @@ class FSBidAdminProjectedVacancyLangOffsetsView(APIView):
         '''
         Get Admin Projected Vacancy Language Offsets
         '''
-        result = services.get_admin_projected_vacancy_lang_offsets(request.data, request.META['HTTP_JWT'])
+        result = services.get_admin_projected_vacancy_lang_offsets(request.query_params, request.META['HTTP_JWT'])
         if result is None:
             return Response(status=status.HTTP_404_NOT_FOUND)
         return Response(result)

--- a/talentmap_api/fsbid/views/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/views/admin_projected_vacancies.py
@@ -170,12 +170,11 @@ class FSBidAdminProjectedVacancyMetadataView(APIView):
 
     permission_classes = [IsAuthenticated, Or(isDjangoGroupMember('bureau_user'), isDjangoGroupMember('superuser'), ) ]
 
-    @swagger_auto_schema(request_body=openapi.Schema(
-        type=openapi.TYPE_OBJECT,
-        properties={
-            'future_vacancy_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Projected Vacancy Seq Num'),
-        }
-    ))
+    @swagger_auto_schema(
+        manual_parameters=[
+            openapi.Parameter("future_vacancy_seq_num", openapi.IN_QUERY, type=openapi.TYPE_STRING, description='Projected Vacancy Seq Num'),
+        ]
+    )
 
     def get(self, request):
         '''
@@ -193,12 +192,11 @@ class FSBidAdminProjectedVacancyLangOffsetsView(APIView):
 
     permission_classes = [IsAuthenticated, Or(isDjangoGroupMember('bureau_user'), isDjangoGroupMember('superuser'), ) ]
 
-    @swagger_auto_schema(request_body=openapi.Schema(
-        type=openapi.TYPE_OBJECT,
-        properties={
-            'positon_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Position Seq Num'),
-        }
-    ))
+    @swagger_auto_schema(
+        manual_parameters=[
+            openapi.Parameter("positon_seq_num", openapi.IN_QUERY, type=openapi.TYPE_STRING, description='Position Seq Num'),
+        ]
+    )
 
     def get(self, request):
         '''

--- a/talentmap_api/fsbid/views/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/views/admin_projected_vacancies.py
@@ -83,7 +83,7 @@ class FSBidAdminProjectedVacancyActionsView(APIView):
             properties={
                 'future_vacancy_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Projected Vacancy Seq Num'),
                 'future_vacancy_seq_num_ref': openapi.Schema(type=openapi.TYPE_STRING, description='Projected Vacancy Seq Num Reference'),
-                'positon_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Position Seq Num'),
+                'position_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Position Seq Num'),
                 'bid_season_code': openapi.Schema(type=openapi.TYPE_STRING, description='Bid Season Code'),
                 'assignment_seq_num_effective': openapi.Schema(type=openapi.TYPE_STRING, description='Assignment Seq Num Effective'),
                 'assignment_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Assignment Seq Num'),
@@ -122,7 +122,7 @@ class FSBidAdminProjectedVacancyEditLangOffsetsView(APIView):
     @swagger_auto_schema(request_body=openapi.Schema(
         type=openapi.TYPE_OBJECT,
         properties={
-            'positon_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Position Seq Num'),
+            'position_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Position Seq Num'),
             'language_offset_summer': openapi.Schema(type=openapi.TYPE_STRING, description='Language Offset Summer'),
             'language_offset_winter': openapi.Schema(type=openapi.TYPE_STRING, description='Language Offset Winter'),
         }
@@ -147,7 +147,7 @@ class FSBidAdminProjectedVacancyEditCapsuleDescView(APIView):
     @swagger_auto_schema(request_body=openapi.Schema(
         type=openapi.TYPE_OBJECT,
         properties={
-            'positon_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Position Seq Num'),
+            'position_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Position Seq Num'),
             'capsule_description': openapi.Schema(type=openapi.TYPE_STRING, description='Capsule Description'),
             'updater_id': openapi.Schema(type=openapi.TYPE_STRING, description='Updater ID'),
             'updated_date': openapi.Schema(type=openapi.TYPE_STRING, description='Updated Date'),
@@ -194,7 +194,7 @@ class FSBidAdminProjectedVacancyLangOffsetsView(APIView):
 
     @swagger_auto_schema(
         manual_parameters=[
-            openapi.Parameter("positon_seq_num", openapi.IN_QUERY, type=openapi.TYPE_STRING, description='Position Seq Num'),
+            openapi.Parameter("position_seq_num", openapi.IN_QUERY, type=openapi.TYPE_STRING, description='Position Seq Num'),
         ]
     )
 

--- a/talentmap_api/fsbid/views/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/views/admin_projected_vacancies.py
@@ -1,10 +1,10 @@
 import logging
 import coreapi
 
+from rest_condition import Or
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.views import APIView
 
 from drf_yasg.utils import swagger_auto_schema
@@ -19,7 +19,7 @@ class FSBidAdminProjectedVacancyFiltersView(APIView):
 
     # ======================== Get PV Filters ========================
 
-    permission_classes = (IsAuthenticatedOrReadOnly,)
+    permission_classes = [IsAuthenticated, Or(isDjangoGroupMember('bureau_user'), isDjangoGroupMember('superuser'), ) ]
 
     def get(self, request):
         '''
@@ -34,7 +34,7 @@ class FSBidAdminProjectedVacancyLanguageOffsetsView(APIView):
 
     # ======================== Get Language Offsets Dropdowns ========================
 
-    permission_classes = (IsAuthenticatedOrReadOnly,)
+    permission_classes = [IsAuthenticated, Or(isDjangoGroupMember('bureau_user'), isDjangoGroupMember('superuser'), ) ]
 
     def get(self, request):
         '''
@@ -49,7 +49,7 @@ class FSBidAdminProjectedVacancyListView(APIView):
 
     # ======================== Get PV List ========================
 
-    permission_classes = (IsAuthenticatedOrReadOnly, )
+    permission_classes = [IsAuthenticated, Or(isDjangoGroupMember('bureau_user'), isDjangoGroupMember('superuser'), ) ]
 
     @swagger_auto_schema(
         manual_parameters=[
@@ -75,30 +75,32 @@ class FSBidAdminProjectedVacancyActionsView(APIView):
     
     # ======================== Edit PV ========================
 
-    permission_classes = [IsAuthenticated, isDjangoGroupMember('superuser'), ]
+    permission_classes = [IsAuthenticated, Or(isDjangoGroupMember('bureau_user'), isDjangoGroupMember('superuser'), ) ]
 
     @swagger_auto_schema(request_body=openapi.Schema(
-        type=openapi.TYPE_OBJECT,
-        properties={
-            'future_vacancy_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Projected Vacancy Seq Num'),
-            'future_vacancy_seq_num_ref': openapi.Schema(type=openapi.TYPE_STRING, description='Projected Vacancy Seq Num Reference'),
-            'positon_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Position Seq Num'),
-            'bid_season_code': openapi.Schema(type=openapi.TYPE_STRING, description='Bid Season Code'),
-            'assignment_seq_num_effective': openapi.Schema(type=openapi.TYPE_STRING, description='Assignment Seq Num Effective'),
-            'assignment_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Assignment Seq Num'),
-            'cycle_date_type_code': openapi.Schema(type=openapi.TYPE_STRING, description='Cycle Date Type Code'),
-            'future_vacancy_status_code': openapi.Schema(type=openapi.TYPE_STRING, description='Status Code'),
-            'future_vacancy_override_code': openapi.Schema(type=openapi.TYPE_STRING, description='Override Code'),
-            'future_vacancy_override_tour_end_date': openapi.Schema(type=openapi.TYPE_STRING, description='Override TED'),
-            'future_vacancy_system_indicator': openapi.Schema(type=openapi.TYPE_STRING, description='System Indicator'),
-            'future_vacancy_comment': openapi.Schema(type=openapi.TYPE_STRING, description='Comment'),
-            'created_date': openapi.Schema(type=openapi.TYPE_STRING, description='Created Date'),
-            'creator_id': openapi.Schema(type=openapi.TYPE_STRING, description='Creator ID'),
-            'updater_id': openapi.Schema(type=openapi.TYPE_STRING, description='Updater ID'),
-            'updated_date': openapi.Schema(type=openapi.TYPE_STRING, description='Updated Date'),
-            'future_vacancy_mc_indicator': openapi.Schema(type=openapi.TYPE_STRING, description='MC Indicator'),
-            'future_vacancy_exclude_import_indicator': openapi.Schema(type=openapi.TYPE_STRING, description='Exclude Import Indicator'),
-        }
+        type=openapi.TYPE_ARRAY, items=openapi.Items(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                'future_vacancy_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Projected Vacancy Seq Num'),
+                'future_vacancy_seq_num_ref': openapi.Schema(type=openapi.TYPE_STRING, description='Projected Vacancy Seq Num Reference'),
+                'positon_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Position Seq Num'),
+                'bid_season_code': openapi.Schema(type=openapi.TYPE_STRING, description='Bid Season Code'),
+                'assignment_seq_num_effective': openapi.Schema(type=openapi.TYPE_STRING, description='Assignment Seq Num Effective'),
+                'assignment_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Assignment Seq Num'),
+                'cycle_date_type_code': openapi.Schema(type=openapi.TYPE_STRING, description='Cycle Date Type Code'),
+                'future_vacancy_status_code': openapi.Schema(type=openapi.TYPE_STRING, description='Status Code'),
+                'future_vacancy_override_code': openapi.Schema(type=openapi.TYPE_STRING, description='Override Code'),
+                'future_vacancy_override_tour_end_date': openapi.Schema(type=openapi.TYPE_STRING, description='Override TED'),
+                'future_vacancy_system_indicator': openapi.Schema(type=openapi.TYPE_STRING, description='System Indicator'),
+                'future_vacancy_comment': openapi.Schema(type=openapi.TYPE_STRING, description='Comment'),
+                'created_date': openapi.Schema(type=openapi.TYPE_STRING, description='Created Date'),
+                'creator_id': openapi.Schema(type=openapi.TYPE_STRING, description='Creator ID'),
+                'updater_id': openapi.Schema(type=openapi.TYPE_STRING, description='Updater ID'),
+                'updated_date': openapi.Schema(type=openapi.TYPE_STRING, description='Updated Date'),
+                'future_vacancy_mc_indicator': openapi.Schema(type=openapi.TYPE_STRING, description='MC Indicator'),
+                'future_vacancy_exclude_import_indicator': openapi.Schema(type=openapi.TYPE_STRING, description='Exclude Import Indicator'),
+            }
+        ), description='Projected Vacancy'
     ))
 
     def put(self, request):
@@ -115,7 +117,7 @@ class FSBidAdminProjectedVacancyEditLangOffsetsView(APIView):
     
     # ======================== Edit PV Language Offsets ========================
 
-    permission_classes = [IsAuthenticated, isDjangoGroupMember('superuser'), ]
+    permission_classes = [IsAuthenticated, Or(isDjangoGroupMember('bureau_user'), isDjangoGroupMember('superuser'), ) ]
 
     @swagger_auto_schema(request_body=openapi.Schema(
         type=openapi.TYPE_OBJECT,
@@ -140,7 +142,7 @@ class FSBidAdminProjectedVacancyEditCapsuleDescView(APIView):
     
     # ======================== Edit PV Capsule Description ========================
 
-    permission_classes = [IsAuthenticated, isDjangoGroupMember('superuser'), ]
+    permission_classes = [IsAuthenticated, Or(isDjangoGroupMember('bureau_user'), isDjangoGroupMember('superuser'), ) ]
 
     @swagger_auto_schema(request_body=openapi.Schema(
         type=openapi.TYPE_OBJECT,
@@ -161,3 +163,50 @@ class FSBidAdminProjectedVacancyEditCapsuleDescView(APIView):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+class FSBidAdminProjectedVacancyMetadataView(APIView):
+    
+    # ======================== Get PV Metadata ========================
+
+    permission_classes = [IsAuthenticated, Or(isDjangoGroupMember('bureau_user'), isDjangoGroupMember('superuser'), ) ]
+
+    @swagger_auto_schema(request_body=openapi.Schema(
+        type=openapi.TYPE_OBJECT,
+        properties={
+            'future_vacancy_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Projected Vacancy Seq Num'),
+        }
+    ))
+
+    def put(self, request):
+        '''
+        Get Admin Projected Vacancy Metadata
+        '''
+        result = services.get_admin_projected_vacancy_metadata(request.data, request.META['HTTP_JWT'])
+        if result is None:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+class FSBidAdminProjectedVacancyLangOffsetsView(APIView):
+    
+    # ======================== Get PV Language Offsets ========================
+
+    permission_classes = [IsAuthenticated, Or(isDjangoGroupMember('bureau_user'), isDjangoGroupMember('superuser'), ) ]
+
+    @swagger_auto_schema(request_body=openapi.Schema(
+        type=openapi.TYPE_OBJECT,
+        properties={
+            'positon_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Position Seq Num'),
+        }
+    ))
+
+    def put(self, request):
+        '''
+        Get Admin Projected Vacancy Language Offsets
+        '''
+        result = services.get_admin_projected_vacancy_lang_offsets(request.data, request.META['HTTP_JWT'])
+        if result is None:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        return Response(status=status.HTTP_204_NO_CONTENT)
+

--- a/talentmap_api/fsbid/views/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/views/admin_projected_vacancies.py
@@ -110,3 +110,54 @@ class FSBidAdminProjectedVacancyActionsView(APIView):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
+    
+class FSBidAdminProjectedVacancyEditLangOffsetsView(APIView):
+    
+    # ======================== Edit PV Language Offsets ========================
+
+    permission_classes = [IsAuthenticated, isDjangoGroupMember('superuser'), ]
+
+    @swagger_auto_schema(request_body=openapi.Schema(
+        type=openapi.TYPE_OBJECT,
+        properties={
+            'positon_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Position Seq Num'),
+            'language_offset_summer': openapi.Schema(type=openapi.TYPE_STRING, description='Language Offset Summer'),
+            'language_offset_winter': openapi.Schema(type=openapi.TYPE_STRING, description='Language Offset Winter'),
+        }
+    ))
+
+    def put(self, request):
+        '''
+        Edit Admin Projected Vacancy Language Offsets
+        '''
+        result = services.edit_admin_projected_vacancy_lang_offsets(request.data, request.META['HTTP_JWT'])
+        if result is None:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+class FSBidAdminProjectedVacancyEditCapsuleDescView(APIView):
+    
+    # ======================== Edit PV Capsule Description ========================
+
+    permission_classes = [IsAuthenticated, isDjangoGroupMember('superuser'), ]
+
+    @swagger_auto_schema(request_body=openapi.Schema(
+        type=openapi.TYPE_OBJECT,
+        properties={
+            'positon_seq_num': openapi.Schema(type=openapi.TYPE_STRING, description='Position Seq Num'),
+            'capsule_description': openapi.Schema(type=openapi.TYPE_STRING, description='Capsule Description'),
+            'updater_id': openapi.Schema(type=openapi.TYPE_STRING, description='Updater ID'),
+            'updated_date': openapi.Schema(type=openapi.TYPE_STRING, description='Updated Date'),
+        }
+    ))
+
+    def put(self, request):
+        '''
+        Edit Admin Projected Vacancy Capsule Description
+        '''
+        result = services.edit_admin_projected_vacancy_capsule_desc(request.data, request.META['HTTP_JWT'])
+        if result is None:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/talentmap_api/fsbid/views/admin_projected_vacancies.py
+++ b/talentmap_api/fsbid/views/admin_projected_vacancies.py
@@ -177,7 +177,7 @@ class FSBidAdminProjectedVacancyMetadataView(APIView):
         }
     ))
 
-    def put(self, request):
+    def get(self, request):
         '''
         Get Admin Projected Vacancy Metadata
         '''
@@ -200,7 +200,7 @@ class FSBidAdminProjectedVacancyLangOffsetsView(APIView):
         }
     ))
 
-    def put(self, request):
+    def get(self, request):
         '''
         Get Admin Projected Vacancy Language Offsets
         '''


### PR DESCRIPTION
Updates:
- Fixed common service response function to allow for universal response JSONs
  - Some back office responses contain different naming conventions for the RETURN_CODE and ERROR_DATA
- Added endpoint for editing PV (general)
- Added endpoint for editing PV language offsets
- Added endpoint for editing PV capsule description
- Added endpoint for getting PV language offsets
- Added endpoint for getting PV metadata

Dual Merge: 
- [FE PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2861)
- [Mock PR](https://github.com/MetaPhase-Consulting/mock-fsbid/pull/437)

[TM-5389](https://metaphase.atlassian.net/browse/TM-5389)


[TM-5389]: https://metaphase.atlassian.net/browse/TM-5389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ