### PR TITLE
5412 tm edit cycle cleanup

### DIFF
--- a/talentmap_api/fsbid/services/assignment_cycles.py
+++ b/talentmap_api/fsbid/services/assignment_cycles.py
@@ -89,8 +89,8 @@ def save_assignment_cycle_req_mapping(req, is_update=False):
     name = data['assignmentCycle']
     cycle_category = data['cycleCategory']
     cycle_status = data['cycleStatus']
-    exclusive_position = 'Y' if data['exclusivePosition'] else 'N'
-    post_viewable = 'Y' if data['postViewable'] else 'N'
+    exclusive_position = data['exclusivePosition']
+    post_viewable = data['postViewable']
 
 
     mapped_request = {


### PR DESCRIPTION
Dual Merge: 
- [Frontend PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2898)

tiny fixes from testing -- the `create_new` cycle logic had the frontend passing in True/False and the backend parsing it... but now the update shares that same service/logic 

made it all more consistent - no more T/F just Y/N 