### PR TITLE
TM-5960: Panel Administrator Role

### DIFF
--- a/talentmap_api/common/management/commands/create_base_permissions.py
+++ b/talentmap_api/common/management/commands/create_base_permissions.py
@@ -23,6 +23,7 @@ class Command(BaseCommand):
             "ao_user",
             "post_user",
             "helppage_editor",
+            "panel_admin",
         ]
 
     def handle(self, *args, **options):

--- a/talentmap_api/common/management/commands/create_base_permissions.py
+++ b/talentmap_api/common/management/commands/create_base_permissions.py
@@ -24,6 +24,7 @@ class Command(BaseCommand):
             "post_user",
             "helppage_editor",
             "panel_admin",
+            "fsbid_admin",
         ]
 
     def handle(self, *args, **options):

--- a/talentmap_api/fsbid/services/employee.py
+++ b/talentmap_api/fsbid/services/employee.py
@@ -90,6 +90,7 @@ ROLE_MAPPING = {
     "Bureau": "bureau_user",
     "AO": "ao_user",
     "FSBID_PA": "panel_admin",
+    "FSBID_SA": "fsbid_admin",
 }
 
 

--- a/talentmap_api/fsbid/services/employee.py
+++ b/talentmap_api/fsbid/services/employee.py
@@ -89,6 +89,7 @@ ROLE_MAPPING = {
     "CDO3": "cdo",
     "Bureau": "bureau_user",
     "AO": "ao_user",
+    "FSBID_PA": "panel_admin",
 }
 
 

--- a/talentmap_api/user_profile/management/commands/create_seeded_users.py
+++ b/talentmap_api/user_profile/management/commands/create_seeded_users.py
@@ -25,7 +25,8 @@ class Command(BaseCommand):
         ("woodwardw", "woodwardw@state.gov", "password", "Wendy", "Woodward", False, False, ["bureau_user"]),
         ("velezp", "velezp@state.gov", "password", "Preston", "Velez", False, False, ["post_user"]),
         ("lincolna", "lincolna@state.gov", "password", "Abigail", "Lincoln", True, False, ["ao_user"]),
-        ("patricka", "patricka@state.gov", "password", "Patrick", "Anthony", False, False, ["panel_admin", "cdo"]),
+        ("anthonyp", "anthonyp@state.gov", "password", "Patrick", "Anthony", False, False, ["panel_admin", "cdo"]),
+        ("andersons", "andersons@state.gov", "password", "Stephanie", "Anderson", False, False, ["fsbid_admin", "cdo"]),
     ]
 
     def handle(self, *args, **options):

--- a/talentmap_api/user_profile/management/commands/create_seeded_users.py
+++ b/talentmap_api/user_profile/management/commands/create_seeded_users.py
@@ -25,7 +25,7 @@ class Command(BaseCommand):
         ("woodwardw", "woodwardw@state.gov", "password", "Wendy", "Woodward", False, False, ["bureau_user"]),
         ("velezp", "velezp@state.gov", "password", "Preston", "Velez", False, False, ["post_user"]),
         ("lincolna", "lincolna@state.gov", "password", "Abigail", "Lincoln", True, False, ["ao_user"]),
-        ("petera", "petera@state.gov", "password", "Peter", "Alistair", False, False, ["panel_admin", "cdo"]),
+        ("patricka", "patricka@state.gov", "password", "Patrick", "Anthony", False, False, ["panel_admin", "cdo"]),
     ]
 
     def handle(self, *args, **options):

--- a/talentmap_api/user_profile/management/commands/create_seeded_users.py
+++ b/talentmap_api/user_profile/management/commands/create_seeded_users.py
@@ -25,6 +25,7 @@ class Command(BaseCommand):
         ("woodwardw", "woodwardw@state.gov", "password", "Wendy", "Woodward", False, False, ["bureau_user"]),
         ("velezp", "velezp@state.gov", "password", "Preston", "Velez", False, False, ["post_user"]),
         ("lincolna", "lincolna@state.gov", "password", "Abigail", "Lincoln", True, False, ["ao_user"]),
+        ("petera", "petera@state.gov", "password", "Peter", "Alistair", False, False, ["panel_admin", "cdo"]),
     ]
 
     def handle(self, *args, **options):


### PR DESCRIPTION
ACs:
1. New Menu Option for Panel Administrator (will reuse admin icon)
2. Submenu for existing panel module

_TRIPLE_ Merge: 
- [FE PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2959)
- [Mock PR](https://github.com/MetaPhase-Consulting/mock-fsbid/pull/471)

[Ticket](https://metaphase.atlassian.net/browse/TM-5960)
