### PR TITLE
[TM-5976-5977] Maintain Separations/Assignments Integration and Refactor

### DIFF
--- a/talentmap_api/fsbid/services/assignment_history.py
+++ b/talentmap_api/fsbid/services/assignment_history.py
@@ -329,8 +329,8 @@ def update_assignment_separation(query, jwt_token, is_separation):
 def update_assignment_req_mapping(request, hru_id):
     return {
         **base_assignment_action_req(request),
-        "I_ASG_SEQ_NUM": request.get("asg_seq_num"),
-        "I_ASGD_REVISION_NUM": request.get("asgd_revision_num"),
+        "I_ASG_SEQ_NUM": request.get("asg_id"),
+        "I_ASGD_REVISION_NUM": request.get("revision_num"),
         "I_ASGD_CRITICAL_NEED_IND": "Y" if request.get("critical_need_ind") else "N",
         "I_ASGD_UPDATE_ID": hru_id,
         "I_ASGD_UPDATE_DATE": request.get("update_date"),
@@ -345,11 +345,11 @@ def update_assignment_res_mapping(data):
 def update_separation_req_mapping(request, hru_id):
     return {
         **base_separation_action_req(request),
-        "I_SEP_SEQ_NUM": request.get("sep_seq_num"),
-        "I_SEPD_REVISION_NUM": request.get("sep_seq_num"),
+        "I_SEP_SEQ_NUM": request.get("sep_id"),
+        "I_SEPD_REVISION_NUM": request.get("revision_num"),
         "I_SEPD_UPDATE_ID": hru_id,
         "I_SEPD_UPDATE_DATE": request.get("updated_date"),
-        "O_SEPD_REVISION_NUM": request.get("sep_revision_number"),
+        "O_SEPD_REVISION_NUM": request.get("o_revision_num"),
         "O_RETURN_CODE": "",
         "QRY_ACTION_DATA": "",
         "QRY_ERROR_DATA": "",

--- a/talentmap_api/fsbid/services/assignment_history.py
+++ b/talentmap_api/fsbid/services/assignment_history.py
@@ -223,7 +223,7 @@ def get_assignment_separation(data, jwt_token, is_separation):
 
 def get_assignment_req_mapping(request):
     return {
-        "i_asg_seq_num": request.get("asg_id"),
+        "i_asg_seq_num": request.get("asg_id") or None,
         "i_asgd_revision_num": request.get("revision_num"),
         "pv_api_version_i": "",
         "pv_ad_id_i": "",
@@ -233,7 +233,7 @@ def get_separation_req_mapping(request):
     return {
         "PV_API_VERSION_I": "",
         "PV_AD_ID_I": "",
-        "I_SEP_SEQ_NUM": request.get("sep_id"),
+        "I_SEP_SEQ_NUM": request.get("sep_id") or None,
         "I_SEPD_REVISION_NUM": request.get("revision_num"),
         "O_SECREF_ROLE_IND": "",
         "QRY_LSTASGS_REF": "",

--- a/talentmap_api/fsbid/services/assignment_history.py
+++ b/talentmap_api/fsbid/services/assignment_history.py
@@ -291,9 +291,9 @@ def base_separation_action_req(request):
         "I_SEPD_SEPARATION_DATE": request.get("separation_date"), 
         "I_SEPD_CITY_TEXT": request.get("city_text"),
         "I_SEPD_COUNTRY_STATE_TEXT": request.get("country_state_text"),
-        "I_SEPD_US_IND": "Y" if request.get("us_ind") else "N",
+        "I_SEPD_US_IND": request.get("us_ind"),
         "I_ASGS_CODE": request.get("status_code"),
-        "I_LAT_CODE": "M", # Should always be "Separation" LAT
+        "I_LAT_CODE": request.get("lat_code"), # Should separation always be "Separation" M LAT?
         "I_TF_CD": request.get("travel_code"),
         "I_WRT_CODE_RR_REPAY": request.get("rr_repay_ind"),
         "I_SEPD_NOTE_COMMMENT_TEXT": "", # No comment feature

--- a/talentmap_api/fsbid/services/assignment_history.py
+++ b/talentmap_api/fsbid/services/assignment_history.py
@@ -254,17 +254,6 @@ def get_alt_separation_req_mapping(request):
         "PV_AD_ID_I": "",
         "I_SEP_SEQ_NUM": None if request.get("ignore_params") else request.get("sep_id"),
         "I_SEPD_REVISION_NUM": None if request.get("ignore_params") else request.get("revision_num"),
-        "O_SECREF_ROLE_IND": "",
-        "QRY_LSTASGS_REF": "",
-        "QRY_LSTLAT_REF": "",
-        "QRY_LSTTF_REF": "",
-        "QRY_LSTWRT_REF": "",
-        "QRY_LSTDIST_REF": "",
-        "QRY_LSTNOTP_REF": "",
-        "QRY_GETSEPDTL_REF": "",
-        "O_RETURN_CODE": "",
-        "QRY_ACTION_DATA": "",
-        "QRY_ERROR_DATA": ""
     }
 
 
@@ -368,10 +357,6 @@ def update_alt_separation_req_mapping(request, hru_id):
         "I_SEPD_REVISION_NUM": request.get("revision_num"),
         "I_SEPD_UPDATE_ID": hru_id,
         "I_SEPD_UPDATE_DATE": request.get("updated_date"),
-        "O_SEPD_REVISION_NUM": "",
-        "O_RETURN_CODE": "",
-        "QRY_ACTION_DATA": "",
-        "QRY_ERROR_DATA": "",
     }
 
 def update_alt_separation_res_mapping(data):

--- a/talentmap_api/fsbid/services/assignment_history.py
+++ b/talentmap_api/fsbid/services/assignment_history.py
@@ -349,7 +349,7 @@ def update_separation_req_mapping(request, hru_id):
         "I_SEPD_REVISION_NUM": request.get("revision_num"),
         "I_SEPD_UPDATE_ID": hru_id,
         "I_SEPD_UPDATE_DATE": request.get("updated_date"),
-        "O_SEPD_REVISION_NUM": request.get("o_revision_num"),
+        "O_SEPD_REVISION_NUM": "",
         "O_RETURN_CODE": "",
         "QRY_ACTION_DATA": "",
         "QRY_ERROR_DATA": "",

--- a/talentmap_api/fsbid/services/assignment_history.py
+++ b/talentmap_api/fsbid/services/assignment_history.py
@@ -163,7 +163,7 @@ def fsbid_assignments_to_talentmap_assignments(data):
 
 # ======== Get Assignments and Separations List ========
 
-def get_all_assignments_separations(id, jwt_token):
+def get_assignments_separations(id, jwt_token):
     '''
     Get assignments and separations by perdet from fsbid proc 
     '''
@@ -179,22 +179,6 @@ def get_all_assignments_separations(id, jwt_token):
         **args
     )
 
-def get_assignments_separations(id, jwt_token, is_separation):
-    '''
-    Get assignments or separations by perdet from fsbid proc 
-    '''
-    args = {
-        "proc_name": 'qry_lstAsgsSeps',
-        "package_name": 'PKG_WEBAPI_WRAP_SPRINT99',
-        "request_mapping_function": get_assignments_separations_req_mapping,
-        "response_mapping_function": get_separations_res_mapping if is_separation else get_assignments_res_mapping,
-        "jwt_token": jwt_token,
-        "request_body": { "perdet_seq_num": id },
-    }
-    return services.send_post_back_office(
-        **args
-    )
-    
 def get_assignments_separations_req_mapping(request):
     return {
         "i_perdet_seq_num": request.get("perdet_seq_num"),
@@ -207,18 +191,6 @@ def get_assignments_separations_res_mapping(data):
         logger.error('FSBid call for fetching assignments and separations failed.')
         return None
     return data
-
-def get_assignments_res_mapping(data):
-    if data is None or (data['O_RETURN_CODE'] and data['O_RETURN_CODE'] is not 0):
-        logger.error('FSBid call for fetching assignments failed.')
-        return None
-    return data.get("QRY_LSTASGS_REF")
-
-def get_separations_res_mapping(data):
-    if data is None or (data['O_RETURN_CODE'] and data['O_RETURN_CODE'] is not 0):
-        logger.error('FSBid call for fetching separations failed.')
-        return None
-    return data.get("QRY_LSTSEPS_REF")
 
 
 # ======== Get Assignment/Separation Detail and Reference Data ========

--- a/talentmap_api/fsbid/services/assignment_history.py
+++ b/talentmap_api/fsbid/services/assignment_history.py
@@ -195,7 +195,7 @@ def get_assignments_separations_res_mapping(data):
 
 # ======== Get Assignment/Separation Detail and Reference Data ========
 
-def get_assignment_separation_detail(data, jwt_token, is_separation):
+def get_assignment_separation(data, jwt_token, is_separation):
     '''
     Get Assignment or Separation Detail and Reference Data
     '''
@@ -203,8 +203,8 @@ def get_assignment_separation_detail(data, jwt_token, is_separation):
         args = {
             "proc_name": 'qry_getSepDtl',
             "package_name": 'PKG_WEBAPI_WRAP_SPRINT99',
-            "request_mapping_function": separation_detail_req_mapping,
-            "response_mapping_function": assignment_separation_detail_res_mapping,
+            "request_mapping_function": get_separation_req_mapping,
+            "response_mapping_function": get_assignment_separation_res_mapping,
             "jwt_token": jwt_token,
             "request_body": data,
         }
@@ -212,8 +212,8 @@ def get_assignment_separation_detail(data, jwt_token, is_separation):
         args = {
             "proc_name": 'qry_getAsgDtl',
             "package_name": 'PKG_WEBAPI_WRAP_SPRINT99',
-            "request_mapping_function": assignment_detail_req_mapping,
-            "response_mapping_function": assignment_separation_detail_res_mapping,
+            "request_mapping_function": get_assignment_req_mapping,
+            "response_mapping_function": get_assignment_separation_res_mapping,
             "jwt_token": jwt_token,
             "request_body": data,
         }
@@ -221,7 +221,7 @@ def get_assignment_separation_detail(data, jwt_token, is_separation):
         **args
     )
 
-def assignment_detail_req_mapping(request):
+def get_assignment_req_mapping(request):
     return {
         "i_asg_seq_num": request.get("asg_id"),
         "i_asgd_revision_num": request.get("revision_num"),
@@ -229,7 +229,7 @@ def assignment_detail_req_mapping(request):
         "pv_ad_id_i": "",
     }
 
-def separation_detail_req_mapping(request):
+def get_separation_req_mapping(request):
     return {
         "PV_API_VERSION_I": "",
         "PV_AD_ID_I": "",
@@ -248,7 +248,7 @@ def separation_detail_req_mapping(request):
         "QRY_ERROR_DATA": ""
     }
 
-def assignment_separation_detail_res_mapping(data):
+def get_assignment_separation_res_mapping(data):
     # if data is None or (data['O_RETURN_CODE'] and data['O_RETURN_CODE'] is not 0):
     #    logger.error('FSBid call for fetching assignment reference data failed.')
     #    return None

--- a/talentmap_api/fsbid/services/assignment_history.py
+++ b/talentmap_api/fsbid/services/assignment_history.py
@@ -289,7 +289,6 @@ def assignment_separation_detail_res_mapping(data):
 
 # ======== Update Assignment/Separation ========
 
-
 def base_assignment_action_req(request):
     return {
         "PV_API_VERSION_I": "",
@@ -310,19 +309,7 @@ def base_assignment_action_req(request):
         "I_ASGD_TF_CD": request.get("travel_code"),
         "I_ASGD_WRT_CODE_RR_REPAY": "Y" if request.get("rr_repay_ind") else "N",
         "I_ASGD_NOTE_COMMENT_TEXT": "", # No comment feature
-
-        # Update
-        "I_ASG_SEQ_NUM": request.get("asg_seq_num"),
-        "I_ASGD_REVISION_NUM": request.get("asgd_revision_num"),
-        "I_ASGD_CRITICAL_NEED_IND": "Y" if request.get("critical_need_ind") else "N",
-        "I_ASGD_UPDATE_ID": hru_id,
-        "I_ASGD_UPDATE_DATE": request.get("update_date"),
-
-        # Create
-        "I_EMP_SEQ_NBR": request.get("employee"),
-        "I_POS_SEQ_NUM": request.get("position"),
     }
-
 
 def base_separation_action_req(request):
     return {
@@ -337,20 +324,7 @@ def base_separation_action_req(request):
         "I_LAT_CODE": "M", # Should always be "Separation" LAT
         "I_TF_CD": request.get("travel_code"),
         "I_WRT_CODE_RR_REPAY": request.get("rr_repay_ind"),
-        "I_SEPD_NOTE_COMMMENT_TEXT": request.get("note"), # No comment feature
-
-        # Update
-        "I_SEP_SEQ_NUM": request.get("sep_seq_num"),
-        "I_SEPD_REVISION_NUM": request.get("sep_seq_num"),
-        "I_SEPD_UPDATE_ID": hru_id,
-        "I_SEPD_UPDATE_DATE": request.get("updated_date"),
-        "O_SEPD_REVISION_NUM": request.get("sep_revision_number"),
-        "O_RETURN_CODE": "",
-        "QRY_ACTION_DATA": "",
-        "QRY_ERROR_DATA": "",
-
-        # Create
-        "I_EMP_SEQ_NBR": request.get("employee"),
+        "I_SEPD_NOTE_COMMMENT_TEXT": "", # No comment feature
     }
 
 def update_assignment_separation(query, jwt_token, is_separation):
@@ -382,28 +356,12 @@ def update_assignment_separation(query, jwt_token, is_separation):
 
 def update_assignment_req_mapping(request, hru_id):
     return {
-        "PV_API_VERSION_I": "",
-        "PV_AD_ID_I": "",
+        **base_assignment_action_req(request),
         "I_ASG_SEQ_NUM": request.get("asg_seq_num"),
         "I_ASGD_REVISION_NUM": request.get("asgd_revision_num"),
-        "I_ASGD_ETA_DATE": request.get("eta"),
-        "I_ASGD_ETD_TED_DATE": request.get("etd"),
-        "I_ASGD_TOD_CODE": request.get("tod"),
-        "I_ASGD_TOD_MONTHS_NUM": request.get("tod_months_num"),
-        "I_ASGD_TOD_OTHER_TEXT": request.get("tod_other_text"),
-        "I_ASGD_ADJUST_MONTHS_NUM": None,
-        "I_ASGD_SALARY_REIMBURSE_IND": "Y" if request.get("salary_reimburse_ind") else "N",
-        "I_ASGD_TRAVEL_REIMBURSE_IND": "Y" if request.get("travel_reimburse_ind") else "N",
-        "I_ASGD_TRAINING_IND": "Y" if request.get("training_ind") else "N",
         "I_ASGD_CRITICAL_NEED_IND": "Y" if request.get("critical_need_ind") else "N",
-        "I_ASGD_ORG_CODE": request.get("org_code"),
-        "I_ASGD_ASGS_CODE": request.get("status_code"),
-        "I_ASGD_LAT_CODE": request.get("lat_code"),
-        "I_ASGD_TF_CD": request.get("travel_code"),
-        "I_ASGD_WRT_CODE_RR_REPAY": "Y" if request.get("rr_repay_ind") else "N",
-        "I_ASGD_NOTE_COMMENT_TEXT": "", # No comment feature
         "I_ASGD_UPDATE_ID": hru_id,
-        "I_ASGD_UPDATE_DATE": request.get("update_date")
+        "I_ASGD_UPDATE_DATE": request.get("update_date"),
     }
 
 def update_assignment_res_mapping(data):
@@ -414,26 +372,15 @@ def update_assignment_res_mapping(data):
     
 def update_separation_req_mapping(request, hru_id):
     return {
-        "PV_API_VERSION_I": "",
-        "PV_AD_ID_I": "",
+        **base_separation_action_req(request),
         "I_SEP_SEQ_NUM": request.get("sep_seq_num"),
         "I_SEPD_REVISION_NUM": request.get("sep_seq_num"),
-        "I_DSC_CD": request.get("location_code"),
-        "I_SEPD_SEPARATION_DATE": request.get("separation_date"), 
-        "I_SEPD_CITY_TEXT": request.get("city_text"),
-        "I_SEPD_COUNTRY_STATE_TEXT": request.get("country_state_text"),
-        "I_SEPD_US_IND": "Y" if request.get("us_ind") else "N",
-        "I_ASGS_CODE": request.get("status_code"),
-        "I_LAT_CODE": "M", # Should always be "Separation" LAT
-        "I_TF_CD": request.get("travel_code"),
-        "I_WRT_CODE_RR_REPAY": request.get("rr_repay_ind"),
-        "I_SEPD_NOTE_COMMMENT_TEXT": request.get("note"), # No comment feature
         "I_SEPD_UPDATE_ID": hru_id,
         "I_SEPD_UPDATE_DATE": request.get("updated_date"),
         "O_SEPD_REVISION_NUM": request.get("sep_revision_number"),
         "O_RETURN_CODE": "",
         "QRY_ACTION_DATA": "",
-        "QRY_ERROR_DATA": ""
+        "QRY_ERROR_DATA": "",
     }
 
 def update_separation_res_mapping(data):
@@ -474,26 +421,9 @@ def create_assignment_separation(query, jwt_token, is_separation):
 
 def create_assignment_req_mapping(request):
     return {
-        "PV_API_VERSION_I": "",
-        "PV_AD_ID_I": "",
+        **base_assignment_action_req(request),
         "I_EMP_SEQ_NBR": request.get("employee"),
         "I_POS_SEQ_NUM": request.get("position"),
-        "I_ASGD_ETA_DATE": request.get("eta"),
-        "I_ASGD_ETD_TED_DATE": request.get("etd"),
-        "I_ASGD_TOD_CODE": request.get("tod"),
-        # TO DO: Clarify custom tod feature
-        "I_ASGD_TOD_MONTHS_NUM": request.get("tod_months_num"), 
-        "I_ASGD_TOD_OTHER_TEXT": request.get("tod_other_text"), 
-        "I_ASGD_ADJUST_MONTHS_NUM": request.get("tod_adjust_months_num"), 
-        "I_ASGD_SALARY_REIMBURSE_IND": "Y" if request.get("salary_reimburse_ind") else "N",
-        "I_ASGD_TRAVEL_REIMBURSE_IND": "Y" if request.get("travel_reimburse_ind") else "N",
-        "I_ASGD_TRAINING_IND": "Y" if request.get("training_ind") else "N",
-        "I_ASGD_ORG_CODE": request.get("org_code"),
-        "I_ASGD_ASGS_CODE": request.get("status_code"),
-        "I_ASGD_LAT_CODE": request.get("lat_code"),
-        "I_ASGD_TF_CD": request.get("travel_code"),
-        "I_ASGD_WRT_CODE_RR_REPAY": request.get("rr_repay_ind"),
-        "I_ASGD_NOTE_COMMMENT_TEXT": "", # No comment feature
     }
 
 def create_assignment_res_mapping(data):
@@ -504,19 +434,8 @@ def create_assignment_res_mapping(data):
 
 def create_separation_req_mapping(request):
     return {
-        "PV_API_VERSION_I": "",
-        "PV_AD_ID_I": "",
+        **base_separation_action_req(request),
         "I_EMP_SEQ_NBR": request.get("employee"),
-        "I_DSC_CD": request.get("location_code"),
-        "I_SEPD_SEPARATION_DATE": request.get("separation_date"), 
-        "I_SEPD_CITY_TEXT": request.get("city_text"),
-        "I_SEPD_COUNTRY_STATE_TEXT": request.get("country_state_text"),
-        "I_SEPD_US_IND": "Y" if request.get("us_ind") else "N",
-        "I_ASGS_CODE": request.get("status_code"),
-        "I_LAT_CODE": "M", # Should always be "Separation" LAT
-        "I_TF_CD": request.get("travel_code"),
-        "I_WRT_CODE_RR_REPAY": request.get("rr_repay_ind"),
-        "I_SEPD_NOTE_COMMMENT_TEXT": request.get("note"), # No comment feature
     }
 
 def create_separation_res_mapping(data):

--- a/talentmap_api/fsbid/services/assignment_history.py
+++ b/talentmap_api/fsbid/services/assignment_history.py
@@ -224,7 +224,7 @@ def get_assignment_separation(data, jwt_token, is_separation):
 def get_assignment_req_mapping(request):
     return {
         "i_asg_seq_num": request.get("asg_id") or None,
-        "i_asgd_revision_num": request.get("revision_num"),
+        "i_asgd_revision_num": request.get("revision_num") or None,
         "pv_api_version_i": "",
         "pv_ad_id_i": "",
     }
@@ -234,7 +234,7 @@ def get_separation_req_mapping(request):
         "PV_API_VERSION_I": "",
         "PV_AD_ID_I": "",
         "I_SEP_SEQ_NUM": request.get("sep_id") or None,
-        "I_SEPD_REVISION_NUM": request.get("revision_num"),
+        "I_SEPD_REVISION_NUM": request.get("revision_num") or None,
         "O_SECREF_ROLE_IND": "",
         "QRY_LSTASGS_REF": "",
         "QRY_LSTLAT_REF": "",
@@ -333,7 +333,7 @@ def update_assignment_req_mapping(request, hru_id):
         "I_ASGD_REVISION_NUM": request.get("revision_num"),
         "I_ASGD_CRITICAL_NEED_IND": "Y" if request.get("critical_need_ind") else "N",
         "I_ASGD_UPDATE_ID": hru_id,
-        "I_ASGD_UPDATE_DATE": request.get("update_date"),
+        "I_ASGD_UPDATE_DATE": request.get("updated_date"),
     }
 
 def update_assignment_res_mapping(data):

--- a/talentmap_api/fsbid/services/assignment_history.py
+++ b/talentmap_api/fsbid/services/assignment_history.py
@@ -233,8 +233,8 @@ def get_separation_req_mapping(request):
     return {
         "PV_API_VERSION_I": "",
         "PV_AD_ID_I": "",
-        "I_SEP_SEQ_NUM": None if request.get("ignore_params") else  request.get("sep_id"),
-        "I_SEPD_REVISION_NUM": None if request.get("ignore_params") else  request.get("revision_num"),
+        "I_SEP_SEQ_NUM": None if request.get("ignore_params") else request.get("sep_id"),
+        "I_SEPD_REVISION_NUM": None if request.get("ignore_params") else request.get("revision_num"),
         "O_SECREF_ROLE_IND": "",
         "QRY_LSTASGS_REF": "",
         "QRY_LSTLAT_REF": "",

--- a/talentmap_api/fsbid/services/assignment_history.py
+++ b/talentmap_api/fsbid/services/assignment_history.py
@@ -15,6 +15,8 @@ API_ROOT = settings.WS_ROOT_API_URL
 logger = logging.getLogger(__name__)
 
 
+# ======== Get Assignment History ========
+
 def get_assignments(query, jwt_token):
     '''
     Get assignments
@@ -31,7 +33,6 @@ def get_assignments(query, jwt_token):
         API_ROOT,
     )
     return response
-
 
 def assignment_history_to_client_format(data):
     # needs to be updated once fully integrated
@@ -92,7 +93,6 @@ def assignment_history_to_client_format(data):
             )
     return tmap_assignments
 
-
 def convert_assignments_query(query):
     filters = services.convert_to_fsbid_ql([
         {"col": "asgperdetseqnum", "val": query.get('perdet_seq_num') or None},
@@ -109,7 +109,6 @@ def convert_assignments_query(query):
     }
     valuesToReturn = pydash.omit_by(values, lambda o: o is None or o == [])
     return urlencode(valuesToReturn, doseq=True, quote_via=quote)
-
 
 def fsbid_assignments_to_talentmap_assignments(data):
     return {
@@ -162,24 +161,95 @@ def fsbid_assignments_to_talentmap_assignments(data):
     }
 
 
-def get_assignment_ref_data(data, jwt_token):
+# ======== Get Assignments and Separations List ========
+
+def get_all_assignments_separations(id, jwt_token):
     '''
-    Get maintain assignment reference data
+    Get assignments and separations by perdet from fsbid proc 
     '''
     args = {
-        "proc_name": 'qry_getAsgDtl',
+        "proc_name": 'qry_lstAsgsSeps',
         "package_name": 'PKG_WEBAPI_WRAP_SPRINT99',
-        "request_mapping_function": asg_ref_data_req_mapping,
-        "response_mapping_function": asg_ref_data_res_mapping,
+        "request_mapping_function": get_assignments_separations_req_mapping,
+        "response_mapping_function": get_assignments_separations_res_mapping,
         "jwt_token": jwt_token,
-        "request_body": data,
+        "request_body": { "perdet_seq_num": id },
     }
     return services.send_post_back_office(
         **args
     )
 
+def get_assignments_separations(id, jwt_token, is_separation):
+    '''
+    Get assignments or separations by perdet from fsbid proc 
+    '''
+    args = {
+        "proc_name": 'qry_lstAsgsSeps',
+        "package_name": 'PKG_WEBAPI_WRAP_SPRINT99',
+        "request_mapping_function": get_assignments_separations_req_mapping,
+        "response_mapping_function": get_separations_res_mapping if is_separation else get_assignments_res_mapping,
+        "jwt_token": jwt_token,
+        "request_body": { "perdet_seq_num": id },
+    }
+    return services.send_post_back_office(
+        **args
+    )
+    
+def get_assignments_separations_req_mapping(request):
+    return {
+        "i_perdet_seq_num": request.get("perdet_seq_num"),
+        "pv_api_version_i": "",
+        "pv_ad_id_i": "",
+    }
 
-def asg_ref_data_req_mapping(request):
+def get_assignments_separations_res_mapping(data):
+    if data is None or (data['O_RETURN_CODE'] and data['O_RETURN_CODE'] is not 0):
+        logger.error('FSBid call for fetching assignments and separations failed.')
+        return None
+    return data
+
+def get_assignments_res_mapping(data):
+    if data is None or (data['O_RETURN_CODE'] and data['O_RETURN_CODE'] is not 0):
+        logger.error('FSBid call for fetching assignments failed.')
+        return None
+    return data.get("QRY_LSTASGS_REF")
+
+def get_separations_res_mapping(data):
+    if data is None or (data['O_RETURN_CODE'] and data['O_RETURN_CODE'] is not 0):
+        logger.error('FSBid call for fetching separations failed.')
+        return None
+    return data.get("QRY_LSTSEPS_REF")
+
+
+# ======== Get Assignment/Separation Detail and Reference Data ========
+
+def get_assignment_separation_detail(data, jwt_token, is_separation):
+    '''
+    Get Assignment or Separation Detail and Reference Data
+    '''
+    if (is_separation):
+        args = {
+            "proc_name": 'qry_getSepDtl',
+            "package_name": 'PKG_WEBAPI_WRAP_SPRINT99',
+            "request_mapping_function": separation_detail_req_mapping,
+            "response_mapping_function": assignment_separation_detail_res_mapping,
+            "jwt_token": jwt_token,
+            "request_body": data,
+        }
+    else:
+        args = {
+            "proc_name": 'qry_getAsgDtl',
+            "package_name": 'PKG_WEBAPI_WRAP_SPRINT99',
+            "request_mapping_function": assignment_detail_req_mapping,
+            "response_mapping_function": assignment_separation_detail_res_mapping,
+            "jwt_token": jwt_token,
+            "request_body": data,
+        }
+    return services.send_post_back_office(
+        **args
+    )
+
+def assignment_detail_req_mapping(request):
     return {
         "i_asg_seq_num": request.get("asg_id"),
         "i_asgd_revision_num": request.get("revision_num"),
@@ -187,8 +257,26 @@ def asg_ref_data_req_mapping(request):
         "pv_ad_id_i": "",
     }
 
+def separation_detail_req_mapping(request):
+    return {
+        "PV_API_VERSION_I": "",
+        "PV_AD_ID_I": "",
+        "I_SEP_SEQ_NUM": request.get("sep_id"),
+        "I_SEPD_REVISION_NUM": request.get("revision_num"),
+        "O_SECREF_ROLE_IND": "",
+        "QRY_LSTASGS_REF": "",
+        "QRY_LSTLAT_REF": "",
+        "QRY_LSTTF_REF": "",
+        "QRY_LSTWRT_REF": "",
+        "QRY_LSTDIST_REF": "",
+        "QRY_LSTNOTP_REF": "",
+        "QRY_GETSEPDTL_REF": "",
+        "O_RETURN_CODE": "",
+        "QRY_ACTION_DATA": "",
+        "QRY_ERROR_DATA": ""
+    }
 
-def asg_ref_data_res_mapping(data):
+def assignment_separation_detail_res_mapping(data):
     # if data is None or (data['O_RETURN_CODE'] and data['O_RETURN_CODE'] is not 0):
     #    logger.error('FSBid call for fetching assignment reference data failed.')
     #    return None
@@ -199,57 +287,100 @@ def asg_ref_data_res_mapping(data):
     return data
 
 
-def alt_get_assignments(id, jwt_token):
-    '''
-    Get assignments and separations by perdet from fsbid proc 
-    '''
-    args = {
-        "proc_name": 'qry_lstAsgsSeps',
-        "package_name": 'PKG_WEBAPI_WRAP_SPRINT99',
-        "request_mapping_function": alt_asg_req_mapping,
-        "response_mapping_function": alt_asg_res_mapping,
-        "jwt_token": jwt_token,
-        "request_body": { "perdet_seq_num": id },
-    }
-    return services.send_post_back_office(
-        **args
-    )
-    
+# ======== Update Assignment/Separation ========
 
-def alt_asg_req_mapping(request):
+
+def base_assignment_action_req(request):
     return {
-        "i_perdet_seq_num": request.get("perdet_seq_num"),
-        "pv_api_version_i": "",
-        "pv_ad_id_i": "",
+        "PV_API_VERSION_I": "",
+        "PV_AD_ID_I": "",
+        "I_ASGD_ETA_DATE": request.get("eta"),
+        "I_ASGD_ETD_TED_DATE": request.get("etd"),
+        "I_ASGD_TOD_CODE": request.get("tod"),
+        # TO DO: Clarify custom tod feature
+        "I_ASGD_TOD_MONTHS_NUM": request.get("tod_months_num"), 
+        "I_ASGD_TOD_OTHER_TEXT": request.get("tod_other_text"), 
+        "I_ASGD_ADJUST_MONTHS_NUM": request.get("tod_adjust_months_num"), 
+        "I_ASGD_SALARY_REIMBURSE_IND": "Y" if request.get("salary_reimburse_ind") else "N",
+        "I_ASGD_TRAVEL_REIMBURSE_IND": "Y" if request.get("travel_reimburse_ind") else "N",
+        "I_ASGD_TRAINING_IND": "Y" if request.get("training_ind") else "N",
+        "I_ASGD_ORG_CODE": request.get("org_code"),
+        "I_ASGD_ASGS_CODE": request.get("status_code"),
+        "I_ASGD_LAT_CODE": request.get("lat_code"),
+        "I_ASGD_TF_CD": request.get("travel_code"),
+        "I_ASGD_WRT_CODE_RR_REPAY": "Y" if request.get("rr_repay_ind") else "N",
+        "I_ASGD_NOTE_COMMENT_TEXT": "", # No comment feature
+
+        # Update
+        "I_ASG_SEQ_NUM": request.get("asg_seq_num"),
+        "I_ASGD_REVISION_NUM": request.get("asgd_revision_num"),
+        "I_ASGD_CRITICAL_NEED_IND": "Y" if request.get("critical_need_ind") else "N",
+        "I_ASGD_UPDATE_ID": hru_id,
+        "I_ASGD_UPDATE_DATE": request.get("update_date"),
+
+        # Create
+        "I_EMP_SEQ_NBR": request.get("employee"),
+        "I_POS_SEQ_NUM": request.get("position"),
     }
 
 
-def alt_asg_res_mapping(data):
-    if data is None or (data['O_RETURN_CODE'] and data['O_RETURN_CODE'] is not 0):
-        logger.error('FSBid call for fetching assignments/separations failed.')
-        return None
-    return data.get('QRY_LSTASGS_REF')
+def base_separation_action_req(request):
+    return {
+        "PV_API_VERSION_I": "",
+        "PV_AD_ID_I": "",
+        "I_DSC_CD": request.get("location_code"),
+        "I_SEPD_SEPARATION_DATE": request.get("separation_date"), 
+        "I_SEPD_CITY_TEXT": request.get("city_text"),
+        "I_SEPD_COUNTRY_STATE_TEXT": request.get("country_state_text"),
+        "I_SEPD_US_IND": "Y" if request.get("us_ind") else "N",
+        "I_ASGS_CODE": request.get("status_code"),
+        "I_LAT_CODE": "M", # Should always be "Separation" LAT
+        "I_TF_CD": request.get("travel_code"),
+        "I_WRT_CODE_RR_REPAY": request.get("rr_repay_ind"),
+        "I_SEPD_NOTE_COMMMENT_TEXT": request.get("note"), # No comment feature
 
+        # Update
+        "I_SEP_SEQ_NUM": request.get("sep_seq_num"),
+        "I_SEPD_REVISION_NUM": request.get("sep_seq_num"),
+        "I_SEPD_UPDATE_ID": hru_id,
+        "I_SEPD_UPDATE_DATE": request.get("updated_date"),
+        "O_SEPD_REVISION_NUM": request.get("sep_revision_number"),
+        "O_RETURN_CODE": "",
+        "QRY_ACTION_DATA": "",
+        "QRY_ERROR_DATA": "",
 
-def alt_update_assignment(query, jwt_token):
+        # Create
+        "I_EMP_SEQ_NBR": request.get("employee"),
+    }
+
+def update_assignment_separation(query, jwt_token, is_separation):
     '''
-    Get assignments and separations by perdet from fsbid proc 
+    Update Assignment or Separation
     '''
     hru_id = jwt.decode(jwt_token, verify=False).get('sub')
-    args = {
-        "proc_name": 'act_modasgdtl',
-        "package_name": 'PKG_WEBAPI_WRAP_SPRINT99',
-        "request_mapping_function": partial(alt_update_asg_req_mapping, hru_id=hru_id),
-        "response_mapping_function": alt_update_asg_res_mapping,
-        "jwt_token": jwt_token,
-        "request_body": query,
-    }
+    if is_separation:
+        args = {
+            "proc_name": 'act_modSepDtl',
+            "package_name": 'PKG_WEBAPI_WRAP_SPRINT99',
+            "request_mapping_function": partial(update_separation_req_mapping, hru_id=hru_id),
+            "response_mapping_function": update_separation_res_mapping,
+            "jwt_token": jwt_token,
+            "request_body": query,
+        }
+    else:
+        args = {
+            "proc_name": 'act_modasgdtl',
+            "package_name": 'PKG_WEBAPI_WRAP_SPRINT99',
+            "request_mapping_function": partial(update_assignment_req_mapping, hru_id=hru_id),
+            "response_mapping_function": update_assignment_res_mapping,
+            "jwt_token": jwt_token,
+            "request_body": query,
+        }
     return services.send_post_back_office(
         **args
     )
-    
 
-def alt_update_asg_req_mapping(request, hru_id):
+def update_assignment_req_mapping(request, hru_id):
     return {
         "PV_API_VERSION_I": "",
         "PV_AD_ID_I": "",
@@ -275,24 +406,55 @@ def alt_update_asg_req_mapping(request, hru_id):
         "I_ASGD_UPDATE_DATE": request.get("update_date")
     }
 
-
-def alt_update_asg_res_mapping(data):
+def update_assignment_res_mapping(data):
     if data is None or (data['O_RETURN_CODE'] and data['O_RETURN_CODE'] is not 0):
         logger.error('FSBid call for updating assignment failed.')
         return None
     return data
+    
+def update_separation_req_mapping(request, hru_id):
+    return {
+        "PV_API_VERSION_I": "",
+        "PV_AD_ID_I": "",
+        "I_SEP_SEQ_NUM": request.get("sep_seq_num"),
+        "I_SEPD_REVISION_NUM": request.get("sep_seq_num"),
+        "I_DSC_CD": request.get("location_code"),
+        "I_SEPD_SEPARATION_DATE": request.get("separation_date"), 
+        "I_SEPD_CITY_TEXT": request.get("city_text"),
+        "I_SEPD_COUNTRY_STATE_TEXT": request.get("country_state_text"),
+        "I_SEPD_US_IND": "Y" if request.get("us_ind") else "N",
+        "I_ASGS_CODE": request.get("status_code"),
+        "I_LAT_CODE": "M", # Should always be "Separation" LAT
+        "I_TF_CD": request.get("travel_code"),
+        "I_WRT_CODE_RR_REPAY": request.get("rr_repay_ind"),
+        "I_SEPD_NOTE_COMMMENT_TEXT": request.get("note"), # No comment feature
+        "I_SEPD_UPDATE_ID": hru_id,
+        "I_SEPD_UPDATE_DATE": request.get("updated_date"),
+        "O_SEPD_REVISION_NUM": request.get("sep_revision_number"),
+        "O_RETURN_CODE": "",
+        "QRY_ACTION_DATA": "",
+        "QRY_ERROR_DATA": ""
+    }
+
+def update_separation_res_mapping(data):
+    if data is None or (data['O_RETURN_CODE'] and data['O_RETURN_CODE'] is not 0):
+        logger.error('FSBid call for updating separation failed.')
+        return None
+    return data
 
 
-def alt_create_assignment(query, jwt_token):
+# ======== Create Assignment/Separation ========
+
+def create_assignment_separation(query, jwt_token, is_separation):
     '''
-    Create assignments separations via fsbid 
+    Create Assignment or Separation
     '''
-    if query.get("is_separation"):
+    if is_separation:
         args = {
             "proc_name": 'act_addsep',
             "package_name": 'PKG_WEBAPI_WRAP_SPRINT99',
-            "request_mapping_function": alt_create_sep_req_mapping,
-            "response_mapping_function": alt_create_sep_res_mapping,
+            "request_mapping_function": create_separation_req_mapping,
+            "response_mapping_function": create_separation_res_mapping,
             "jwt_token": jwt_token,
             "request_body": query,
         }
@@ -300,8 +462,8 @@ def alt_create_assignment(query, jwt_token):
         args = {
             "proc_name": 'qry_addasg',
             "package_name": 'PKG_WEBAPI_WRAP_SPRINT99',
-            "request_mapping_function": alt_create_asg_req_mapping,
-            "response_mapping_function": alt_create_asg_res_mapping,
+            "request_mapping_function": create_assignment_req_mapping,
+            "response_mapping_function": create_assignment_res_mapping,
             "jwt_token": jwt_token,
             "request_body": query,
         }
@@ -310,33 +472,7 @@ def alt_create_assignment(query, jwt_token):
         **args
     )
 
-
-def alt_create_sep_req_mapping(request):
-    return {
-        "PV_API_VERSION_I": "",
-        "PV_AD_ID_I": "",
-        "I_EMP_SEQ_NBR": request.get("employee"),
-        "I_DSC_CD": request.get("location_code"),
-        "I_SEPD_SEPARATION_DATE": request.get("etd"), 
-        "I_SEPD_CITY_TEXT": request.get("city"),
-        "I_SEPD_COUNTRY_STATE_TEXT": request.get("country"),
-        "I_SEPD_US_IND": "Y" if request.get("separation_ind") else "N",
-        "I_ASGS_CODE": request.get("status_code"),
-        "I_LAT_CODE": "M", # Should always be separtion LAT?
-        "I_TF_CD": request.get("travel_code"),
-        "I_WRT_CODE_RR_REPAY": request.get("rr_repay_ind"),
-        "I_SEPD_NOTE_COMMMENT_TEXT": "", # No comment feature
-    }
-
-
-def alt_create_sep_res_mapping(data):
-    if data is None or (data['O_RETURN_CODE'] and data['O_RETURN_CODE'] is not 0):
-        logger.error('FSBid call for creating separation failed.')
-        return None
-    return data
-
-   
-def alt_create_asg_req_mapping(request):
+def create_assignment_req_mapping(request):
     return {
         "PV_API_VERSION_I": "",
         "PV_AD_ID_I": "",
@@ -360,10 +496,31 @@ def alt_create_asg_req_mapping(request):
         "I_ASGD_NOTE_COMMMENT_TEXT": "", # No comment feature
     }
 
-def alt_create_asg_res_mapping(data):
+def create_assignment_res_mapping(data):
     if data is None or (data['O_RETURN_CODE'] and data['O_RETURN_CODE'] is not 0):
         logger.error('FSBid call for creating assignment failed.')
         return None
     return data
 
+def create_separation_req_mapping(request):
+    return {
+        "PV_API_VERSION_I": "",
+        "PV_AD_ID_I": "",
+        "I_EMP_SEQ_NBR": request.get("employee"),
+        "I_DSC_CD": request.get("location_code"),
+        "I_SEPD_SEPARATION_DATE": request.get("separation_date"), 
+        "I_SEPD_CITY_TEXT": request.get("city_text"),
+        "I_SEPD_COUNTRY_STATE_TEXT": request.get("country_state_text"),
+        "I_SEPD_US_IND": "Y" if request.get("us_ind") else "N",
+        "I_ASGS_CODE": request.get("status_code"),
+        "I_LAT_CODE": "M", # Should always be "Separation" LAT
+        "I_TF_CD": request.get("travel_code"),
+        "I_WRT_CODE_RR_REPAY": request.get("rr_repay_ind"),
+        "I_SEPD_NOTE_COMMMENT_TEXT": request.get("note"), # No comment feature
+    }
 
+def create_separation_res_mapping(data):
+    if data is None or (data['O_RETURN_CODE'] and data['O_RETURN_CODE'] is not 0):
+        logger.error('FSBid call for creating separation failed.')
+        return None
+    return data

--- a/talentmap_api/fsbid/services/assignment_history.py
+++ b/talentmap_api/fsbid/services/assignment_history.py
@@ -223,8 +223,8 @@ def get_assignment_separation(data, jwt_token, is_separation):
 
 def get_assignment_req_mapping(request):
     return {
-        "i_asg_seq_num": request.get("asg_id") or None,
-        "i_asgd_revision_num": request.get("revision_num") or None,
+        "i_asg_seq_num": None if request.get("ignore_params") else request.get("asg_id"),
+        "i_asgd_revision_num": None if request.get("ignore_params") else  request.get("revision_num"),
         "pv_api_version_i": "",
         "pv_ad_id_i": "",
     }
@@ -233,8 +233,8 @@ def get_separation_req_mapping(request):
     return {
         "PV_API_VERSION_I": "",
         "PV_AD_ID_I": "",
-        "I_SEP_SEQ_NUM": request.get("sep_id") or None,
-        "I_SEPD_REVISION_NUM": request.get("revision_num") or None,
+        "I_SEP_SEQ_NUM": None if request.get("ignore_params") else  request.get("sep_id"),
+        "I_SEPD_REVISION_NUM": None if request.get("ignore_params") else  request.get("revision_num"),
         "O_SECREF_ROLE_IND": "",
         "QRY_LSTASGS_REF": "",
         "QRY_LSTLAT_REF": "",

--- a/talentmap_api/fsbid/urls/assignment_history.py
+++ b/talentmap_api/fsbid/urls/assignment_history.py
@@ -7,8 +7,11 @@ router = routers.SimpleRouter()
 
 urlpatterns = [
     url(r'^(?P<pk>[0-9]+)/$', views.FSBidAssignmentHistoryListView.as_view(), name="assignment-history-list"),
-    url(r'^(?P<pk>[0-9]+)/alt/$', views.FSBidAltAssignmentHistoryListView.as_view(), name="alt-assignment-history-list"),
-    url(r'^(?P<pk>[-\w]+)/assignment/(?P<asg_id>[-\w]+)/$', views.FSBidAssignmentReferenceView.as_view(), name="assignment-ref-data"),
+    url(r'^(?P<pk>[-\w]+)/assignments-separations/$', views.FSBidMaintainAssignmentsSeparationsListView.as_view(), name="maintain-assignments-separations-list"),
+    url(r'^(?P<pk>[-\w]+)/assignments/$', views.FSBidMaintainAssignmentsBaseView.as_view(), name="maintain-assignments-base"),
+    url(r'^(?P<pk>[-\w]+)/separations/$', views.FSBidmaintainSeparationsListBaseView.as_view(), name="maintain-separations-base"),
+    url(r'^(?P<pk>[-\w]+)/assignments/(?P<id>[-\w]+)/$', views.FSBidMaintainAssignmentsActionView.as_view(), name="maintain-assignments-actions"),
+    url(r'^(?P<pk>[-\w]+)/separations/(?P<id>[-\w]+)/$', views.FSBidmaintainSeparationsListActionView.as_view(), name="maintain-separations-actions"),
     url(r'^$', views.FSBidPrivateAssignmentHistoryListView.as_view(), name="private-assignment-history-list"),
 ]
 

--- a/talentmap_api/fsbid/urls/assignment_history.py
+++ b/talentmap_api/fsbid/urls/assignment_history.py
@@ -7,11 +7,11 @@ router = routers.SimpleRouter()
 
 urlpatterns = [
     url(r'^(?P<pk>[0-9]+)/$', views.FSBidAssignmentHistoryListView.as_view(), name="assignment-history-list"),
-    url(r'^(?P<pk>[-\w]+)/assignments-separations/$', views.FSBidMaintainAssignmentsSeparationsListView.as_view(), name="maintain-assignments-separations-list"),
-    url(r'^(?P<pk>[-\w]+)/assignments/$', views.FSBidMaintainAssignmentsBaseView.as_view(), name="maintain-assignments-base"),
-    url(r'^(?P<pk>[-\w]+)/separations/$', views.FSBidmaintainSeparationsListBaseView.as_view(), name="maintain-separations-base"),
-    url(r'^(?P<pk>[-\w]+)/assignments/(?P<id>[-\w]+)/$', views.FSBidMaintainAssignmentsActionView.as_view(), name="maintain-assignments-actions"),
-    url(r'^(?P<pk>[-\w]+)/separations/(?P<id>[-\w]+)/$', views.FSBidmaintainSeparationsListActionView.as_view(), name="maintain-separations-actions"),
+    url(r'^(?P<pk>[-\w]+)/assignments-separations/$', views.FSBidAltAssignmentsSeparationsListView.as_view(), name="alt-assignments-separations-list"),
+    url(r'^(?P<pk>[-\w]+)/assignments/$', views.FSBidAltAssignmentsBaseView.as_view(), name="alt-assignments-base"),
+    url(r'^(?P<pk>[-\w]+)/separations/$', views.FSBidAltSeparationsListBaseView.as_view(), name="alt-separations-base"),
+    url(r'^(?P<pk>[-\w]+)/assignments/(?P<id>[-\w]+)/$', views.FSBidAltAssignmentsActionView.as_view(), name="alt-assignments-actions"),
+    url(r'^(?P<pk>[-\w]+)/separations/(?P<id>[-\w]+)/$', views.FSBidAltSeparationsListActionView.as_view(), name="alt-separations-actions"),
     url(r'^$', views.FSBidPrivateAssignmentHistoryListView.as_view(), name="private-assignment-history-list"),
 ]
 

--- a/talentmap_api/fsbid/views/assignment_history.py
+++ b/talentmap_api/fsbid/views/assignment_history.py
@@ -68,16 +68,11 @@ class FSBidMaintainAssignmentsSeparationsListView(APIView):
         '''
         Get Maintain Assignments and Separations List
         '''
-        return Response(services.get_all_assignments_separations(pk, request.META['HTTP_JWT']))
+        return Response(services.get_assignments_separations(pk, request.META['HTTP_JWT']))
 
 # ======== Maintain Assignments ========
 
 class FSBidMaintainAssignmentsBaseView(APIView):
-    def get(self, request, pk):
-        '''
-        Get Maintain Assignments List
-        '''
-        return Response(services.get_assignments_separations(pk, request.META['HTTP_JWT'], 0))
     def post(self, request):
         '''
         Create Assignment
@@ -105,11 +100,6 @@ class FSBidMaintainAssignmentsActionView(BaseView):
 # ======== Maintain Separations ========
 
 class FSBidmaintainSeparationsListBaseView(APIView):
-    def get(self, request, pk):
-        '''
-        Get Maintain Separations List
-        '''
-        return Response(services.get_assignments_separations(pk, request.META['HTTP_JWT'], 1))
     def post(self, request):
         '''
         Create Separation

--- a/talentmap_api/fsbid/views/assignment_history.py
+++ b/talentmap_api/fsbid/views/assignment_history.py
@@ -88,8 +88,6 @@ class FSBidAltAssignmentsActionView(BaseView):
             **request.data,
             "perdet_seq_num": pk,
             "asg_id": id,
-            "revision_num": request.query_params.get("revision_num"),
-            "ignore_params": request.query_params.get("ignore_params"),
         }
         return Response(services.get_assignment_separation(query, request.META['HTTP_JWT'], 0))
     def post(self, request, pk, id):
@@ -100,8 +98,6 @@ class FSBidAltAssignmentsActionView(BaseView):
             **request.data,
             "perdet_seq_num": pk,
             "asg_id": id,
-            "revision_num": request.query_params.get("revision_num"),
-            "ignore_params": request.query_params.get("ignore_params"),
         }
         return Response(services.update_assignment_separation(query, request.META['HTTP_JWT'], 0))
     
@@ -121,9 +117,9 @@ class FSBidAltSeparationsListActionView(BaseView):
         Get Separation Detail and Reference Data
         '''
         query = { 
+            **request.data,
             "perdet_seq_num": pk,
             "sep_id": id,
-            "revision_num": request.query_params.get("revision_num"),
         }
         return Response(services.get_assignment_separation(query, request.META['HTTP_JWT'], 1))
     def post(self, request, pk, id):
@@ -134,6 +130,5 @@ class FSBidAltSeparationsListActionView(BaseView):
             **request.data,
             "perdet_seq_num": pk,
             "sep_id": id,
-            "revision_num": request.query_params.get("revision_num"),
         }
         return Response(services.update_assignment_separation(query, request.META['HTTP_JWT'], 1))

--- a/talentmap_api/fsbid/views/assignment_history.py
+++ b/talentmap_api/fsbid/views/assignment_history.py
@@ -85,7 +85,7 @@ class FSBidAltAssignmentsActionView(BaseView):
         Get Assignment Detail and Reference Data
         '''
         query = { 
-            **request.data,
+            **request.query_params,
             "perdet_seq_num": pk,
             "asg_id": id,
         }
@@ -117,7 +117,7 @@ class FSBidAltSeparationsListActionView(BaseView):
         Get Separation Detail and Reference Data
         '''
         query = { 
-            **request.data,
+            **request.query_params,
             "perdet_seq_num": pk,
             "sep_id": id,
         }

--- a/talentmap_api/fsbid/views/assignment_history.py
+++ b/talentmap_api/fsbid/views/assignment_history.py
@@ -77,7 +77,7 @@ class FSBidAltAssignmentsBaseView(APIView):
         '''
         Create Assignment
         '''
-        return Response(services.create_assignment_separation(request.data, request.META['HTTP_JWT'], 0))
+        return Response(services.create_alt_assignment(request.data, request.META['HTTP_JWT']))
 
 class FSBidAltAssignmentsActionView(BaseView):
     def get(self, request, pk, id):
@@ -90,7 +90,7 @@ class FSBidAltAssignmentsActionView(BaseView):
             "revision_num": request.query_params.get("revision_num"),
             "ignore_params": request.query_params.get("ignore_params"),
         }
-        return Response(services.get_assignment_separation(query, request.META['HTTP_JWT'], 0))
+        return Response(services.get_alt_assignment(query, request.META['HTTP_JWT']))
     def put(self, request, pk, id):
         '''
         Update Assignment
@@ -100,7 +100,7 @@ class FSBidAltAssignmentsActionView(BaseView):
             "perdet_seq_num": pk,
             "asg_id": id,
         }
-        return Response(services.update_assignment_separation(query, request.META['HTTP_JWT'], 0))
+        return Response(services.update_alt_assignment(query, request.META['HTTP_JWT']))
     
 
 # ======== Alternative Separations ========
@@ -110,7 +110,7 @@ class FSBidAltSeparationsListBaseView(APIView):
         '''
         Create Separation
         '''
-        return Response(services.create_assignment_separation(request.data, request.META['HTTP_JWT'], 1))
+        return Response(services.create_alt_separation(request.data, request.META['HTTP_JWT']))
     
 class FSBidAltSeparationsListActionView(BaseView):
     def get(self, request, pk, id):
@@ -123,7 +123,7 @@ class FSBidAltSeparationsListActionView(BaseView):
             "revision_num": request.query_params.get("revision_num"),
             "ignore_params": request.query_params.get("ignore_params"),
         }
-        return Response(services.get_assignment_separation(query, request.META['HTTP_JWT'], 1))
+        return Response(services.get_alt_separation(query, request.META['HTTP_JWT']))
     def put(self, request, pk, id):
         '''
         Update Separation
@@ -133,4 +133,4 @@ class FSBidAltSeparationsListActionView(BaseView):
             "perdet_seq_num": pk,
             "sep_id": id,
         }
-        return Response(services.update_assignment_separation(query, request.META['HTTP_JWT'], 1))
+        return Response(services.update_alt_separation(query, request.META['HTTP_JWT']))

--- a/talentmap_api/fsbid/views/assignment_history.py
+++ b/talentmap_api/fsbid/views/assignment_history.py
@@ -85,9 +85,9 @@ class FSBidAltAssignmentsActionView(BaseView):
         Get Assignment Detail and Reference Data
         '''
         query = { 
-            **request.query_params,
             "perdet_seq_num": pk,
             "asg_id": id,
+            "revision_num": request.query_params.get("revision_num"),
         }
         return Response(services.get_assignment_separation(query, request.META['HTTP_JWT'], 0))
     def put(self, request, pk, id):
@@ -117,9 +117,9 @@ class FSBidAltSeparationsListActionView(BaseView):
         Get Separation Detail and Reference Data
         '''
         query = { 
-            **request.query_params,
             "perdet_seq_num": pk,
             "sep_id": id,
+            "revision_num": request.query_params.get("revision_num"),
         }
         return Response(services.get_assignment_separation(query, request.META['HTTP_JWT'], 1))
     def put(self, request, pk, id):

--- a/talentmap_api/fsbid/views/assignment_history.py
+++ b/talentmap_api/fsbid/views/assignment_history.py
@@ -88,6 +88,7 @@ class FSBidAltAssignmentsActionView(BaseView):
             "perdet_seq_num": pk,
             "asg_id": id,
             "revision_num": request.query_params.get("revision_num"),
+            "ignore_params": request.query_params.get("ignore_params"),
         }
         return Response(services.get_assignment_separation(query, request.META['HTTP_JWT'], 0))
     def put(self, request, pk, id):
@@ -120,6 +121,7 @@ class FSBidAltSeparationsListActionView(BaseView):
             "perdet_seq_num": pk,
             "sep_id": id,
             "revision_num": request.query_params.get("revision_num"),
+            "ignore_params": request.query_params.get("ignore_params"),
         }
         return Response(services.get_assignment_separation(query, request.META['HTTP_JWT'], 1))
     def put(self, request, pk, id):

--- a/talentmap_api/fsbid/views/assignment_history.py
+++ b/talentmap_api/fsbid/views/assignment_history.py
@@ -85,9 +85,11 @@ class FSBidAltAssignmentsActionView(BaseView):
         Get Assignment Detail and Reference Data
         '''
         query = { 
+            **request.data,
             "perdet_seq_num": pk,
             "asg_id": id,
             "revision_num": request.query_params.get("revision_num"),
+            "ignore_params": request.query_params.get("ignore_params"),
         }
         return Response(services.get_assignment_separation(query, request.META['HTTP_JWT'], 0))
     def post(self, request, pk, id):
@@ -99,6 +101,7 @@ class FSBidAltAssignmentsActionView(BaseView):
             "perdet_seq_num": pk,
             "asg_id": id,
             "revision_num": request.query_params.get("revision_num"),
+            "ignore_params": request.query_params.get("ignore_params"),
         }
         return Response(services.update_assignment_separation(query, request.META['HTTP_JWT'], 0))
     

--- a/talentmap_api/fsbid/views/assignment_history.py
+++ b/talentmap_api/fsbid/views/assignment_history.py
@@ -73,7 +73,7 @@ class FSBidAltAssignmentsSeparationsListView(APIView):
 # ======== Alternative Assignments ========
 
 class FSBidAltAssignmentsBaseView(APIView):
-    def post(self, request):
+    def post(self, request, pk):
         '''
         Create Assignment
         '''
@@ -105,7 +105,7 @@ class FSBidAltAssignmentsActionView(BaseView):
 # ======== Alternative Separations ========
 
 class FSBidAltSeparationsListBaseView(APIView):
-    def post(self, request):
+    def post(self, request, pk):
         '''
         Create Separation
         '''

--- a/talentmap_api/fsbid/views/assignment_history.py
+++ b/talentmap_api/fsbid/views/assignment_history.py
@@ -90,11 +90,17 @@ class FSBidAltAssignmentsActionView(BaseView):
             "revision_num": request.query_params.get("revision_num"),
         }
         return Response(services.get_assignment_separation(query, request.META['HTTP_JWT'], 0))
-    def patch(self, request):
+    def patch(self, request, pk, id):
         '''
         Update Assignment
         '''
-        return Response(services.update_assignment_separation(request.data, request.META['HTTP_JWT'], 0))
+        query = { 
+            **request.data,
+            "perdet_seq_num": pk,
+            "asg_id": id,
+            "revision_num": request.query_params.get("revision_num"),
+        }
+        return Response(services.update_assignment_separation(query, request.META['HTTP_JWT'], 0))
     
 
 # ======== Alternative Separations ========
@@ -117,8 +123,14 @@ class FSBidAltSeparationsListActionView(BaseView):
             "revision_num": request.query_params.get("revision_num"),
         }
         return Response(services.get_assignment_separation(query, request.META['HTTP_JWT'], 1))
-    def patch(self, request):
+    def patch(self, request, pk, id):
         '''
         Update Separation
         '''
-        return Response(services.update_assignment_separation(request.data, request.META['HTTP_JWT'], 1))
+        query = { 
+            **request.data,
+            "perdet_seq_num": pk,
+            "sep_id": id,
+            "revision_num": request.query_params.get("revision_num"),
+        }
+        return Response(services.update_assignment_separation(query, request.META['HTTP_JWT'], 1))

--- a/talentmap_api/fsbid/views/assignment_history.py
+++ b/talentmap_api/fsbid/views/assignment_history.py
@@ -61,25 +61,25 @@ class FSBidPrivateAssignmentHistoryListView(BaseView):
             logger.error(f"{type(e).__name__} at line {e.__traceback__.tb_lineno} of {__file__}: {e}. User {self.request.user}")
             return Response(status=status.HTTP_422_UNPROCESSABLE_ENTITY)
 
-# ======== Maintain Assignments/Separations ========
+# ======== Alternative Assignments/Separations ========
 
-class FSBidMaintainAssignmentsSeparationsListView(APIView):
+class FSBidAltAssignmentsSeparationsListView(APIView):
     def get(self, request, pk):
         '''
-        Get Maintain Assignments and Separations List
+        Get Alternative Assignments and Separations List
         '''
         return Response(services.get_assignments_separations(pk, request.META['HTTP_JWT']))
 
-# ======== Maintain Assignments ========
+# ======== Alternative Assignments ========
 
-class FSBidMaintainAssignmentsBaseView(APIView):
+class FSBidAltAssignmentsBaseView(APIView):
     def post(self, request):
         '''
         Create Assignment
         '''
         return Response(services.create_assignment_separation(request.data, request.META['HTTP_JWT'], 0))
 
-class FSBidMaintainAssignmentsActionView(BaseView):
+class FSBidAltAssignmentsActionView(BaseView):
     def get(self, request, pk, id):
         '''
         Get Assignment Detail and Reference Data
@@ -97,16 +97,16 @@ class FSBidMaintainAssignmentsActionView(BaseView):
         return Response(services.update_assignment_separation(request.data, request.META['HTTP_JWT'], 0))
     
 
-# ======== Maintain Separations ========
+# ======== Alternative Separations ========
 
-class FSBidmaintainSeparationsListBaseView(APIView):
+class FSBidAltSeparationsListBaseView(APIView):
     def post(self, request):
         '''
         Create Separation
         '''
         return Response(services.create_assignment_separation(request.data, request.META['HTTP_JWT'], 1))
     
-class FSBidmaintainSeparationsListActionView(BaseView):
+class FSBidAltSeparationsListActionView(BaseView):
     def get(self, request, pk, id):
         '''
         Get Separation Detail and Reference Data

--- a/talentmap_api/fsbid/views/assignment_history.py
+++ b/talentmap_api/fsbid/views/assignment_history.py
@@ -90,7 +90,7 @@ class FSBidAltAssignmentsActionView(BaseView):
             "revision_num": request.query_params.get("revision_num"),
         }
         return Response(services.get_assignment_separation(query, request.META['HTTP_JWT'], 0))
-    def patch(self, request, pk, id):
+    def post(self, request, pk, id):
         '''
         Update Assignment
         '''
@@ -123,7 +123,7 @@ class FSBidAltSeparationsListActionView(BaseView):
             "revision_num": request.query_params.get("revision_num"),
         }
         return Response(services.get_assignment_separation(query, request.META['HTTP_JWT'], 1))
-    def patch(self, request, pk, id):
+    def post(self, request, pk, id):
         '''
         Update Separation
         '''

--- a/talentmap_api/fsbid/views/assignment_history.py
+++ b/talentmap_api/fsbid/views/assignment_history.py
@@ -90,7 +90,7 @@ class FSBidAltAssignmentsActionView(BaseView):
             "asg_id": id,
         }
         return Response(services.get_assignment_separation(query, request.META['HTTP_JWT'], 0))
-    def post(self, request, pk, id):
+    def put(self, request, pk, id):
         '''
         Update Assignment
         '''
@@ -122,7 +122,7 @@ class FSBidAltSeparationsListActionView(BaseView):
             "sep_id": id,
         }
         return Response(services.get_assignment_separation(query, request.META['HTTP_JWT'], 1))
-    def post(self, request, pk, id):
+    def put(self, request, pk, id):
         '''
         Update Separation
         '''

--- a/talentmap_api/fsbid/views/assignment_history.py
+++ b/talentmap_api/fsbid/views/assignment_history.py
@@ -89,7 +89,7 @@ class FSBidAltAssignmentsActionView(BaseView):
             "asg_id": id,
             "revision_num": request.query_params.get("revision_num"),
         }
-        return Response(services.get_assignment_separation_detail(query, request.META['HTTP_JWT'], 0))
+        return Response(services.get_assignment_separation(query, request.META['HTTP_JWT'], 0))
     def patch(self, request):
         '''
         Update Assignment
@@ -116,7 +116,7 @@ class FSBidAltSeparationsListActionView(BaseView):
             "sep_id": id,
             "revision_num": request.query_params.get("revision_num"),
         }
-        return Response(services.get_assignment_separation_detail(query, request.META['HTTP_JWT'], 1))
+        return Response(services.get_assignment_separation(query, request.META['HTTP_JWT'], 1))
     def patch(self, request):
         '''
         Update Separation


### PR DESCRIPTION
## Cosmetic Changes:
- Standardized naming conventions
- Reordered code blocks
- Organized URLs and views to follow REST standards
- Made base request mapping functions for create/update on assignments and separations
  - Only change in one place instead of multiple

## Logic Changes:
- Adapted get assignments list to include separations list
- Corrected create separation endpoint
- Added update separation endpoint
- Added get separation detail endpoint

## Dual Merge: 
- [FE PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/2966)
- [Mock PR](https://github.com/MetaPhase-Consulting/mock-fsbid/pull/469)

[TM-5976](https://metaphase.atlassian.net/browse/TM-5976)
[TM-5977](https://metaphase.atlassian.net/browse/TM-5977)


[TM-5976]: https://metaphase.atlassian.net/browse/TM-5976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TM-5977]: https://metaphase.atlassian.net/browse/TM-5977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ