### PR TITLE
handle a WS fail return for Delete AI

### DIFF
--- a/talentmap_api/fsbid/views/agenda.py
+++ b/talentmap_api/fsbid/views/agenda.py
@@ -38,8 +38,11 @@ class AgendaItemDeleteView(BaseView):
         Delete single agenda by ai_seq_num
         '''
         try:
-            services.delete_agenda_item(request.data, request.META['HTTP_JWT'])
-            return Response(status=status.HTTP_204_NO_CONTENT)
+            res = services.delete_agenda_item(request.data, request.META['HTTP_JWT'])
+            if res.json().get('return_code') is 0:
+                return Response(status=status.HTTP_204_NO_CONTENT)
+            else:
+                return Response(status=status.HTTP_400_BAD_REQUEST)
         except Exception as e:
             return Response(status=status.HTTP_422_UNPROCESSABLE_ENTITY)
         


### PR DESCRIPTION
FE already set up to handle a fail.

This is to handle when WS tells us something has failed, which is different from a fail on the actual WS call, which will be handled in the Except.



To simulate different fails:

**WS return fail**
in mock, for `app.delete('/v1/agendas/:aiseqnum'` change `return_code` to something other than 0
```
res.status(200).send({
    Data: {},
    usl_id: 0,
    return_code: -1,
})
```

**WS call fail**
in mock, change the url to something random, that way our API won't find it and it will fail. This will process as a 422 return to our FE.
`app.delete('/v1/agendas/:aiseqnum', async function(req, res) {`
⬇️
`app.delete('/v1/somethingRandom/:aiseqnum', async function(req, res) {`