### PR TITLE
update panel remark mapping (api)

### DIFF
--- a/talentmap_api/fsbid/services/panel.py
+++ b/talentmap_api/fsbid/services/panel.py
@@ -22,7 +22,8 @@ panel_remarks_mapping = {
     'airremarktext': 'air_remark_text',
     'rmrkseqnum': 'seq_num',
     'rmrkrccode': 'rc_code',
-    "rmrkshortdesctext": "short_desc_text"
+    'rmrkshortdesctext': 'short_desc_text',
+    'rmrkactiveind': 'active_ind'
 }
 
 panel_dates_mapping = {


### PR DESCRIPTION
Dual Merge: 
- [Mock PR](https://github.com/MetaPhase-Consulting/mock-fsbid/pull/506)
- [FE PR](https://github.com/MetaPhase-Consulting/State-TalentMAP/pull/3070)

[Ticket](https://metaphase.atlassian.net/browse/TM-6409)

Updated panel remark mapping to include new data point

Verify
- on UI, you should see the word (Legacy) in front of panel remarks on panel meetings page
